### PR TITLE
Update file identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - **💼 Multiple Logging Styles**: Choose from print, OSLog, and SwiftLog styles.
 - **🔧 Flexible and Customizable**: Extend the framework to fit specific logging requirements.
 - **🚀 Easy Integration**: Quick setup with Swift Package Manager.
+- **🆕 Swift 6 File IDs**: Cleaner log output using `#fileID`.
 
 ## Compatibility
 

--- a/Sources/WrkstrmLog/Log+Shared.swift
+++ b/Sources/WrkstrmLog/Log+Shared.swift
@@ -25,7 +25,7 @@ extension Log {
   ///   - dso: The address of the shared object where the log message is generated.
   public static func verbose(
     _ describable: Any,
-    file: String = #file,
+    file: String = #fileID,
     function: String = #function,
     line: UInt = #line,
     column: UInt = #column,
@@ -52,7 +52,7 @@ extension Log {
   ///   - dso: The address of the shared object where the log message is generated.
   public static func info(
     _ describable: Any,
-    file: String = #file,
+    file: String = #fileID,
     function: String = #function,
     line: UInt = #line,
     column: UInt = #column,
@@ -79,7 +79,7 @@ extension Log {
   ///   - dso: The address of the shared object where the log message is generated.
   public static func error(
     _ describable: Any,
-    file: String = #file,
+    file: String = #fileID,
     function: String = #function,
     line: UInt = #line,
     column: UInt = #column,
@@ -107,7 +107,7 @@ extension Log {
   /// - Returns: Never, indicating a fatal error.
   public static func `guard`(
     _ describable: Any? = nil,
-    file: String = #file,
+    file: String = #fileID,
     function: String = #function,
     line: UInt = #line,
     column: UInt = #column,

--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -132,7 +132,7 @@ public struct Log: Hashable, @unchecked Sendable {
   ///   - dso: The address of the shared object where the log message is generated.
   public func verbose(
     _ describable: Any,
-    file: String = #file,
+    file: String = #fileID,
     function: String = #function,
     line: UInt = #line,
     column: UInt = #column,
@@ -161,7 +161,7 @@ public struct Log: Hashable, @unchecked Sendable {
   ///   - dso: The address of the shared object where the log message is generated.
   public func info(
     _ describable: Any = "",
-    file: String = #file,
+    file: String = #fileID,
     function: String = #function,
     line: UInt = #line,
     column: UInt = #column,
@@ -190,7 +190,7 @@ public struct Log: Hashable, @unchecked Sendable {
   ///   - dso: The address of the shared object where the log message is generated.
   public func error(
     _ describable: Any,
-    file: String = #file,
+    file: String = #fileID,
     function: String = #function,
     line: UInt = #line,
     column: UInt = #column,
@@ -220,7 +220,7 @@ public struct Log: Hashable, @unchecked Sendable {
   /// - Returns: Never, indicating a fatal error.
   public func `guard`(
     _ describable: Any? = nil,
-    file: String = #file,
+    file: String = #fileID,
     function: String = #function,
     line: UInt = #line,
     column: UInt = #column,


### PR DESCRIPTION
## Summary
- switch to `#fileID` to shorten file path output
- document Swift 6 usage in README

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688997742b848333b3483434075f5261