### PR TITLE
Lower verbose log severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Import `WrkstrmLog` and start logging with ease:
    ```
 
 3. **📝 Log Messages**:
-   Use various logging methods like `verbose`, `info`, `error`, and `guard`:
+   Use various logging methods like `verbose`, `info`, `error`, and `guard`.
+   `verbose` logs are emitted at the debug level, making them lower
+   priority than informational messages:
 
    ```swift
    logger.verbose("Verbose message")

--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -123,6 +123,9 @@ public struct Log: Hashable, @unchecked Sendable {
 
   /// Logs a verbose message with the specified parameters.
   ///
+  /// Verbose output is mapped to the `.debug` log level so it can be
+  /// easily filtered separately from informational logs.
+  ///
   /// - Parameters:
   ///   - string: The message string to log.
   ///   - file: The source file where the log message is generated.
@@ -139,8 +142,10 @@ public struct Log: Hashable, @unchecked Sendable {
     dso: UnsafeRawPointer = #dsohandle,
   ) {
     guard style != .disabled else { return }
+    // Verbose messages are lower priority than standard informational logs.
+    // Map them to the debug log level so they can be filtered separately.
     log(
-      .info,
+      .debug,
       describable: describable,
       file: file,
       function: function,


### PR DESCRIPTION
## Summary
- set `Log.verbose` to use `.debug` level when calling `log()`
- clarify in `README` that verbose logs are debug-level

## Testing
- `swift test -c release`

------
https://chatgpt.com/codex/tasks/task_e_688c44c92f148333b216c631887a5af9