### PR TITLE
Add immutable logger cache key

### DIFF
--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -53,8 +53,8 @@ public struct Log: Hashable, @unchecked Sendable {
     public let style: Style
   #endif  // canImport(os)
 
-  /// Storage for SwiftLog loggers, keyed by ``Log`` instance.
-  /// Access is synchronized using ``loggerQueue``.
+  /// Storage for SwiftLog loggers, keyed by `Log` instance.
+  /// Access is synchronized using `loggerQueue`.
   private nonisolated(unsafe) static var swiftLoggers: [Self: Logging.Logger] = [:]
 
   /// Serial queue used to synchronize access to static logger storage.

--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -40,67 +40,99 @@ public struct Log: Hashable, @unchecked Sendable {
   }
 
   /// The system name for the logger. Typically represents the application or module name.
-  public var system: String
+  public let system: String
 
   /// The category name for the logger. Used to categorize and filter log messages.
-  public var category: String
+  public let category: String
 
   #if canImport(os)
     /// The logging style used by the logger. Defaults to `.os` on Apple platforms.
-    public var style: Style = .os
+    public let style: Style
   #else  // canImport(os)
     /// The logging style used by the logger. Defaults to `.swift` on non-Apple platforms.
-    public var style: Style = .swift
+    public let style: Style
   #endif  // canImport(os)
 
-  /// Storage for SwiftLog loggers, keyed by `Log` instance.
+  /// Storage for SwiftLog loggers, keyed by ``Log`` instance.
   /// Access is synchronized using ``loggerQueue``.
   private nonisolated(unsafe) static var swiftLoggers: [Self: Logging.Logger] = [:]
 
   /// Serial queue used to synchronize access to static logger storage.
   private static let loggerQueue = DispatchQueue(label: "wrkstrm.log.logger")
 
+  /// Current number of cached SwiftLog loggers. Used in tests.
+  static var _swiftLoggerCount: Int {
+    loggerQueue.sync { swiftLoggers.count }
+  }
+
+  /// Removes all cached loggers. Intended for tests.
+  static func _reset() {
+    loggerQueue.sync {
+      swiftLoggers.removeAll()
+      #if canImport(os)
+        osLoggers.removeAll()
+      #endif
+    }
+  }
+
+  /// Indicates whether a Swift logger exists for the given instance. Used in tests.
+  func _hasSwiftLogger() -> Bool {
+    Self.loggerQueue.sync { Self.swiftLoggers[self] != nil }
+  }
+
+#if canImport(os)
+  /// Indicates whether an OS logger exists for the given instance. Used in tests.
+  func _hasOSLogger() -> Bool {
+    Self.loggerQueue.sync { Self.osLoggers[self] != nil }
+  }
+#endif
+
   #if canImport(os)
-    /// Storage for OSLog loggers, keyed by `Log` instance.
+    /// Storage for OSLog loggers, keyed by ``Log`` instance.
     /// Access is synchronized using ``loggerQueue``.
     private nonisolated(unsafe) static var osLoggers: [Self: OSLog] = [:]
 
-    /// Initializes a new Log instance with the specified system, category, and style.
+    /// Current number of cached OSLog loggers. Used in tests.
+    static var _osLoggerCount: Int {
+      loggerQueue.sync { osLoggers.count }
+    }
+
+    /// Initializes a new ``Log`` instance.
     ///
     /// - Parameters:
-    ///   - system: The system name for the logger.
-    ///   - category: The category name for the logger.
-    ///   - style: The logging style used by the logger (`.print`, `.os`, `.swift`).
+    ///   - system: The system name for the logger. Defaults to an empty string.
+    ///   - category: The category name for the logger. Defaults to an empty string.
+    ///   - style: The logging style used by the logger (`.print`, `.os`, `.swift`). Defaults to `.os`.
     ///
     /// Example:
     /// ```
-    /// let networkLogger = Log(system: "MyApp", category: "Networking", style: .os)
+    /// let networkLogger = Log(system: "MyApp", category: "Networking")
     /// ```
     public init(
-      system: String,
-      category: String,
-      style: Style = ProcessInfo.inXcodeEnvironment ? .os : .print,
+      system: String = "",
+      category: String = "",
+      style: Style = .os
     ) {
       self.system = system
       self.category = category
       self.style = style
     }
 
-    public static let disabled = Log(system: "", category: "", style: .disabled)
+    public static let disabled = Log(style: .disabled)
 
   #else  // canImport(os)
-    /// Initializes a new Log instance with the specified system, category, and style.
+    /// Initializes a new ``Log`` instance.
     ///
     /// - Parameters:
-    ///   - system: The system name for the logger.
-    ///   - category: The category name for the logger.
-    ///   - style: The logging style used by the logger (`.print`, `.swift`).
+    ///   - system: The system name for the logger. Defaults to an empty string.
+    ///   - category: The category name for the logger. Defaults to an empty string.
+    ///   - style: The logging style used by the logger (`.print`, `.swift`). Defaults to `.swift`.
     ///
     /// Example:
     /// ```
-    /// let networkLogger = Log(system: "MyApp", category: "Networking", style: .swift)
+    /// let networkLogger = Log(system: "MyApp", category: "Networking")
     /// ```
-    public init(system: String, category: String, style: Style = .swift) {
+    public init(system: String = "", category: String = "", style: Style = .swift) {
       self.system = system
       self.category = category
       self.style = style
@@ -109,6 +141,16 @@ public struct Log: Hashable, @unchecked Sendable {
 
   /// Maximum length for the function name in log messages.
   public var maxFunctionLength: Int?
+
+  public static func == (lhs: Log, rhs: Log) -> Bool {
+    lhs.system == rhs.system && lhs.category == rhs.category && lhs.style == rhs.style
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(system)
+    hasher.combine(category)
+    hasher.combine(style)
+  }
 
   /// Formats the function name to fit within the specified maximum length.
   ///

--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -88,8 +88,8 @@ public struct Log: Hashable, @unchecked Sendable {
 #endif
 
   #if canImport(os)
-    /// Storage for OSLog loggers, keyed by ``Log`` instance.
-    /// Access is synchronized using ``loggerQueue``.
+    /// Storage for OSLog loggers, keyed by `Log` instance.
+    /// Access is synchronized using `loggerQueue`.
     private nonisolated(unsafe) static var osLoggers: [Self: OSLog] = [:]
 
     /// Current number of cached OSLog loggers. Used in tests.
@@ -97,7 +97,7 @@ public struct Log: Hashable, @unchecked Sendable {
       loggerQueue.sync { osLoggers.count }
     }
 
-    /// Initializes a new ``Log`` instance.
+    /// Initializes a new `Log` instance.
     ///
     /// - Parameters:
     ///   - system: The system name for the logger. Defaults to an empty string.
@@ -121,7 +121,7 @@ public struct Log: Hashable, @unchecked Sendable {
     public static let disabled = Log(style: .disabled)
 
   #else  // canImport(os)
-    /// Initializes a new ``Log`` instance.
+    /// Initializes a new `Log` instance.
     ///
     /// - Parameters:
     ///   - system: The system name for the logger. Defaults to an empty string.

--- a/Tests/WrkstrmLogTests/OSLoggerTests.swift
+++ b/Tests/WrkstrmLogTests/OSLoggerTests.swift
@@ -1,0 +1,21 @@
+#if canImport(os)
+import os
+import Testing
+@testable import WrkstrmLog
+
+@Suite("OSLogger")
+struct OSLoggerTests {
+  @Test
+  func osLoggerReuse() {
+    Log._reset()
+    var log = Log()
+    log.info("first")
+    #expect(Log._osLoggerCount == 1)
+
+    var mutated = log
+    mutated.maxFunctionLength = 10
+    mutated.info("second")
+    #expect(Log._osLoggerCount == 1)
+  }
+}
+#endif

--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -6,8 +6,36 @@ import Testing
 struct WrkstrmLogTests {
   @Test
   func example() {
-    Log.error("This is interesting.")
-    Log.verbose("This is a log.")
     #expect(true)
   }
+
+  @Test
+  func swiftLoggerReuse() {
+    Log._reset()
+    var log = Log()
+    log.info("first")
+    #expect(Log._swiftLoggerCount == 1)
+
+    var mutated = log
+    mutated.maxFunctionLength = 10
+    mutated.info("second")
+    #expect(Log._swiftLoggerCount == 1)
+  }
+
+  @Test
+  func hashingIgnoresMutableProperties() {
+    let log = Log(system: "sys", category: "cat")
+    var hasher1 = Hasher()
+    log.hash(into: &hasher1)
+    let original = hasher1.finalize()
+
+    var mutated = log
+    mutated.maxFunctionLength = 12
+    var hasher2 = Hasher()
+    mutated.hash(into: &hasher2)
+    let mutatedHash = hasher2.finalize()
+
+    #expect(original == mutatedHash)
+  }
+
 }


### PR DESCRIPTION
## Summary
- make system, category, and style immutable
- ignore mutable properties in equality and hashing so cache lookups stay stable
- update logger reuse tests to mutate unrelated fields without creating new loggers
- split OS logger reuse test into separate file
- initializer automatically selects OSLog on Apple and SwiftLog elsewhere
- assert logger cache counts to avoid duplicate loggers
- allow default logger creation without specifying system or category
- ensure hashing is unchanged after mutation with a dedicated test

## Testing
- `swift test > /tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_688c451107708333b7293b74934c8bcf