### PR TITLE
Fix SwiftLint violations

### DIFF
--- a/.wrkstrm/clia/AGENTS.md
+++ b/.wrkstrm/clia/AGENTS.md
@@ -1,6 +1,4 @@
 # Agent Instructions
 
-- Run SwiftLint using `/tmp/swiftlint/swiftlint` for lint checks.
 - Format modified Swift files with `swift format -i -r -p` before committing.
 - Prefer line-scoped disables such as `// swiftlint:disable:this` instead of disable/enable blocks.
-

--- a/.wrkstrm/clia/AGENTS.md
+++ b/.wrkstrm/clia/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+- Run SwiftLint using `/tmp/swiftlint/swiftlint` for lint checks.
+- Format modified Swift files with `swift format -i -r -p` before committing.
+- Prefer line-scoped disables such as `// swiftlint:disable:this` instead of disable/enable blocks.
+

--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -1,6 +1,6 @@
+import Dispatch
 import Foundation
 import Logging
-import Dispatch
 
 #if canImport(os)
   import os
@@ -27,9 +27,11 @@ public struct Log: Hashable, @unchecked Sendable {
     /// Typically used for debugging in local or development environments.
     case print
     #if canImport(os)
+      // swiftlint:disable identifier_name
       /// OSLog style, logs messages using Apple's Unified Logging System (OSLog).
       /// Recommended for production use on Apple platforms for detailed and performant logging.
       case os
+    // swiftlint:enable identifier_name
     #endif  // canImport(os)
     /// Swift style, logs messages using Swift's built-in logging framework (SwiftLog).
     /// Ideal for server-side Swift applications or when consistent logging behavior across
@@ -60,11 +62,14 @@ public struct Log: Hashable, @unchecked Sendable {
   /// Serial queue used to synchronize access to static logger storage.
   private static let loggerQueue = DispatchQueue(label: "wrkstrm.log.logger")
 
+  // swiftlint:disable identifier_name
   /// Current number of cached SwiftLog loggers. Used in tests.
   static var _swiftLoggerCount: Int {
     loggerQueue.sync { swiftLoggers.count }
   }
+  // swiftlint:enable identifier_name
 
+  // swiftlint:disable identifier_name
   /// Removes all cached loggers. Intended for tests.
   static func _reset() {
     loggerQueue.sync {
@@ -74,35 +79,43 @@ public struct Log: Hashable, @unchecked Sendable {
       #endif
     }
   }
+  // swiftlint:enable identifier_name
 
+  // swiftlint:disable identifier_name
   /// Indicates whether a Swift logger exists for the given instance. Used in tests.
   func _hasSwiftLogger() -> Bool {
     Self.loggerQueue.sync { Self.swiftLoggers[self] != nil }
   }
+  // swiftlint:enable identifier_name
 
-#if canImport(os)
-  /// Indicates whether an OS logger exists for the given instance. Used in tests.
-  func _hasOSLogger() -> Bool {
-    Self.loggerQueue.sync { Self.osLoggers[self] != nil }
-  }
-#endif
+  #if canImport(os)
+    // swiftlint:disable identifier_name
+    /// Indicates whether an OS logger exists for the given instance. Used in tests.
+    func _hasOSLogger() -> Bool {
+      Self.loggerQueue.sync { Self.osLoggers[self] != nil }
+    }
+  // swiftlint:enable identifier_name
+  #endif
 
   #if canImport(os)
     /// Storage for OSLog loggers, keyed by `Log` instance.
     /// Access is synchronized using `loggerQueue`.
     private nonisolated(unsafe) static var osLoggers: [Self: OSLog] = [:]
 
+    // swiftlint:disable identifier_name
     /// Current number of cached OSLog loggers. Used in tests.
     static var _osLoggerCount: Int {
       loggerQueue.sync { osLoggers.count }
     }
+    // swiftlint:enable identifier_name
 
     /// Initializes a new `Log` instance.
     ///
     /// - Parameters:
     ///   - system: The system name for the logger. Defaults to an empty string.
     ///   - category: The category name for the logger. Defaults to an empty string.
-    ///   - style: The logging style used by the logger (`.print`, `.os`, `.swift`). Defaults to `.os`.
+    ///   - style: The logging style used by the logger (`.print`, `.os`, `.swift`).
+    ///     Defaults to `.os`.
     ///
     /// Example:
     /// ```
@@ -286,7 +299,7 @@ public struct Log: Hashable, @unchecked Sendable {
     fatalError("Guard failed: \(String(describing: describable))")
   }
 
-  // swiftlint:disable:next function_parameter_count
+  // swiftlint:disable:next function_parameter_count function_body_length
   private func log(
     _ level: Logging.Logger.Level,
     describable: Any,
@@ -330,17 +343,17 @@ public struct Log: Hashable, @unchecked Sendable {
         )
     #endif  // canImport(os)
 
-      case .swift:
-        let logger: Logging.Logger = Self.loggerQueue.sync {
-          if let existing = Self.swiftLoggers[self] {
-            return existing
-          }
-          var newLogger = Logging.Logger(label: system)
-          newLogger.logLevel = .debug
-          Self.swiftLoggers[self] = newLogger
-          return newLogger
+    case .swift:
+      let logger: Logging.Logger = Self.loggerQueue.sync {
+        if let existing = Self.swiftLoggers[self] {
+          return existing
         }
-        logger.log(
+        var newLogger = Logging.Logger(label: system)
+        newLogger.logLevel = .debug
+        Self.swiftLoggers[self] = newLogger
+        return newLogger
+      }
+      logger.log(
         level: level,
         "\(line)|\(functionString)| \(String(describing: describable))",
         source: url.lastPathComponent,
@@ -349,7 +362,8 @@ public struct Log: Hashable, @unchecked Sendable {
         line: line,
       )
 
-    case .disabled: break
+    case .disabled:
+      break
     }
   }
 }

--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -27,11 +27,9 @@ public struct Log: Hashable, @unchecked Sendable {
     /// Typically used for debugging in local or development environments.
     case print
     #if canImport(os)
-      // swiftlint:disable identifier_name
       /// OSLog style, logs messages using Apple's Unified Logging System (OSLog).
       /// Recommended for production use on Apple platforms for detailed and performant logging.
-      case os
-    // swiftlint:enable identifier_name
+      case os  // swiftlint:disable:this identifier_name
     #endif  // canImport(os)
     /// Swift style, logs messages using Swift's built-in logging framework (SwiftLog).
     /// Ideal for server-side Swift applications or when consistent logging behavior across
@@ -62,16 +60,13 @@ public struct Log: Hashable, @unchecked Sendable {
   /// Serial queue used to synchronize access to static logger storage.
   private static let loggerQueue = DispatchQueue(label: "wrkstrm.log.logger")
 
-  // swiftlint:disable identifier_name
   /// Current number of cached SwiftLog loggers. Used in tests.
-  static var _swiftLoggerCount: Int {
+  static var _swiftLoggerCount: Int {  // swiftlint:disable:this identifier_name
     loggerQueue.sync { swiftLoggers.count }
   }
-  // swiftlint:enable identifier_name
 
-  // swiftlint:disable identifier_name
   /// Removes all cached loggers. Intended for tests.
-  static func _reset() {
+  static func _reset() {  // swiftlint:disable:this identifier_name
     loggerQueue.sync {
       swiftLoggers.removeAll()
       #if canImport(os)
@@ -79,22 +74,17 @@ public struct Log: Hashable, @unchecked Sendable {
       #endif
     }
   }
-  // swiftlint:enable identifier_name
 
-  // swiftlint:disable identifier_name
   /// Indicates whether a Swift logger exists for the given instance. Used in tests.
-  func _hasSwiftLogger() -> Bool {
+  func _hasSwiftLogger() -> Bool {  // swiftlint:disable:this identifier_name
     Self.loggerQueue.sync { Self.swiftLoggers[self] != nil }
   }
-  // swiftlint:enable identifier_name
 
   #if canImport(os)
-    // swiftlint:disable identifier_name
     /// Indicates whether an OS logger exists for the given instance. Used in tests.
-    func _hasOSLogger() -> Bool {
+    func _hasOSLogger() -> Bool {  // swiftlint:disable:this identifier_name
       Self.loggerQueue.sync { Self.osLoggers[self] != nil }
     }
-  // swiftlint:enable identifier_name
   #endif
 
   #if canImport(os)
@@ -102,12 +92,10 @@ public struct Log: Hashable, @unchecked Sendable {
     /// Access is synchronized using `loggerQueue`.
     private nonisolated(unsafe) static var osLoggers: [Self: OSLog] = [:]
 
-    // swiftlint:disable identifier_name
     /// Current number of cached OSLog loggers. Used in tests.
-    static var _osLoggerCount: Int {
+    static var _osLoggerCount: Int {  // swiftlint:disable:this identifier_name
       loggerQueue.sync { osLoggers.count }
     }
-    // swiftlint:enable identifier_name
 
     /// Initializes a new `Log` instance.
     ///


### PR DESCRIPTION
## Summary
- run `swift-format` on logging sources
- wrap documentation and underscore helpers with `swiftlint` disable/enable blocks
- suppress parameter-count and body-length rules on internal log helper

## Testing
- `/tmp/swiftlint/swiftlint`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_688fbae4712483339d3236a75b9b1525