### PR TITLE
docs: document 1.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [1.1.2] - 2024-08-29
+### Added
+- Adopt Swift 6 `#fileID` identifiers for cleaner, more consistent log output across platforms.
+- Lower verbose log level and update documentation to reflect the new severity.
+- Improve URL initialization and path handling, adding unit tests to verify behavior.
+- Introduce an immutable logger cache key with comprehensive test coverage.
+- Refine linting and formatting guidance, running `swift-format` and scoping SwiftLint suppressions.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add `WrkstrmLog` as a dependency in your `Package.swift` file:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/wrkstrm/WrkstrmLog.git", .upToNextMajor(from: "1.1.0"))
+    .package(url: "https://github.com/wrkstrm/WrkstrmLog.git", .upToNextMajor(from: "1.1.2"))
 ]
 ```
 
@@ -158,7 +158,7 @@ func someFunction() {
 Add this line to your `Package.swift` and let the magic begin:
 ```swift
 dependencies: [
-    .package(url: "https://github.com/wrkstrm/WrkstrmLog.git", .upToNextMajor(from: "1.1.0"))
+    .package(url: "https://github.com/wrkstrm/WrkstrmLog.git", .upToNextMajor(from: "1.1.2"))
 ]
 ```
 


### PR DESCRIPTION
## Summary
- document the 1.1.2 release in a new changelog
- update README dependency examples to reference version 1.1.2

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_688fce6f3d3c83339de3c677cd645d4d