### PR TITLE
Implement disabled logging style for release builds

### DIFF
--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -12,7 +12,7 @@ struct WrkstrmLogTests {
   @Test
   func swiftLoggerReuse() {
     Log._reset()
-    var log = Log()
+    var log = Log(style: .swift)
     log.info("first")
     #expect(Log._swiftLoggerCount == 1)
 
@@ -44,4 +44,28 @@ struct WrkstrmLogTests {
     logger.info("Testing path", file: "/tmp/Some Folder/File Name.swift")
     #expect(true)
   }
+
+  @Test
+  func disabledProducesNoLoggers() {
+    Log._reset()
+    Log.disabled.info("silence")
+    #expect(Log._swiftLoggerCount == 0)
+  }
+
+  #if DEBUG
+    @Test
+    func defaultLoggerNotDisabledInDebug() {
+      let log = Log()
+      #expect(log.style != .disabled)
+    }
+  #else
+    @Test
+    func defaultLoggerDisabledInRelease() {
+      Log._reset()
+      let log = Log()
+      log.info("silence")
+      #expect(log.style == .disabled)
+      #expect(Log._swiftLoggerCount == 0)
+    }
+  #endif
 }


### PR DESCRIPTION
## Summary
- document and expose the `disabled` logging style for use in release builds
- default `Log` to `disabled` when `DEBUG` is not defined
- test that `Log.disabled` and release builds avoid creating loggers

## Testing
- `swift test`
- `swift test -c release`


------
https://chatgpt.com/codex/tasks/task_e_688fddfbd5d88333812f5526f67b16f6