### PR TITLE
feat: add production option for loggers

### DIFF
--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -12,7 +12,7 @@ struct WrkstrmLogTests {
   @Test
   func swiftLoggerReuse() {
     Log._reset()
-    var log = Log(style: .swift)
+    let log = Log(style: .swift, options: [.prod])
     log.info("first")
     #expect(Log._swiftLoggerCount == 1)
 
@@ -66,6 +66,15 @@ struct WrkstrmLogTests {
       log.info("silence")
       #expect(log.style == .disabled)
       #expect(Log._swiftLoggerCount == 0)
+    }
+
+    @Test
+    func loggerWithProdOptionEnabledInRelease() {
+      Log._reset()
+      let log = Log(style: .swift, options: [.prod])
+      log.info("hello")
+      #expect(log.style == .swift)
+      #expect(Log._swiftLoggerCount == 1)
     }
   #endif
 }


### PR DESCRIPTION
## Summary
- add `Log.Options` bitmask to allow keeping loggers active in production
- disable loggers in prod unless `.prod` option is set
- test production option and logger reuse across build configurations

## Testing
- `swift test`
- `swift test -c release`


------
https://chatgpt.com/codex/tasks/task_e_688feb18e7548333a2c95bd24445c120