### PR TITLE
Add scaffolding for WrkstrmPerformance CLI

### DIFF
--- a/.wrkstrm/clia/AGENTS.md
+++ b/.wrkstrm/clia/AGENTS.md
@@ -2,3 +2,5 @@
 
 - Format modified Swift files with `swift format -i -r -p` before committing.
 - Prefer line-scoped disables such as `// swiftlint:disable:this` instead of disable/enable blocks.
+- Use the `WrkstrmPerformance` CLI to run external commands and capture metrics when validating
+  performance hypotheses.

--- a/AGENCY.md
+++ b/AGENCY.md
@@ -1,0 +1,7 @@
+# WrkstrmPerformance
+
+The `WrkstrmPerformance` CLI runs another command and exposes hooks for monitoring its execution.
+Use this tool when experimenting with code or system changes to validate performance hypotheses by
+running the target command under observation.
+
+This document will evolve as metrics collection is added.

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,8 @@ let package = Package(
     .watchOS(.v9),
   ],
   products: [
-    .library(name: "WrkstrmLog", targets: ["WrkstrmLog"])
+    .library(name: "WrkstrmLog", targets: ["WrkstrmLog"]),
+    .executable(name: "WrkstrmPerformance", targets: ["WrkstrmPerformance"])
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.0"),
@@ -26,6 +27,11 @@ let package = Package(
       name: "WrkstrmLog",
       dependencies: [.product(name: "Logging", package: "swift-log")],
       swiftSettings: Package.Inject.shared.swiftSettings,
+    ),
+    .executableTarget(
+      name: "WrkstrmPerformance",
+      dependencies: ["WrkstrmLog"],
+      swiftSettings: Package.Inject.shared.swiftSettings
     ),
     .testTarget(name: "WrkstrmLogTests", dependencies: ["WrkstrmLog"]),
   ],

--- a/Sources/WrkstrmPerformance/PerformanceRunner.swift
+++ b/Sources/WrkstrmPerformance/PerformanceRunner.swift
@@ -1,0 +1,24 @@
+import Foundation
+import WrkstrmLog
+
+/// Scaffolding for running and monitoring a subprocess.
+public struct PerformanceRunner {
+  public init() {}
+
+  /// Launches a subprocess and returns the running `Process` instance.
+  /// - Parameters:
+  ///   - command: Path to the executable to run.
+  ///   - arguments: Arguments to pass to the executable.
+  /// - Returns: A running `Process` instance.
+  @discardableResult
+  public func run(command: String, arguments: [String]) throws -> Process {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: command)
+    process.arguments = arguments
+    process.standardOutput = Pipe()
+    process.standardError = Pipe()
+    // TODO: Capture and report performance metrics.
+    try process.run()
+    return process
+  }
+}

--- a/Sources/WrkstrmPerformance/WrkstrmPerformanceCLI.swift
+++ b/Sources/WrkstrmPerformance/WrkstrmPerformanceCLI.swift
@@ -6,7 +6,7 @@ struct WrkstrmPerformanceCLI {
   static func main() throws {
     let arguments = CommandLine.arguments
     guard arguments.count > 1 else {
-      print("Usage: wrkstrmperformance <command> [arguments...]")
+      print("Usage: WrkstrmPerformance <command> [arguments...]")
       return
     }
     let command = arguments[1]

--- a/Sources/WrkstrmPerformance/WrkstrmPerformanceCLI.swift
+++ b/Sources/WrkstrmPerformance/WrkstrmPerformanceCLI.swift
@@ -1,0 +1,19 @@
+import Foundation
+import WrkstrmLog
+
+@main
+struct WrkstrmPerformanceCLI {
+  static func main() throws {
+    let arguments = CommandLine.arguments
+    guard arguments.count > 1 else {
+      print("Usage: wrkstrmperformance <command> [arguments...]")
+      return
+    }
+    let command = arguments[1]
+    let commandArgs = Array(arguments.dropFirst(2))
+    let runner = PerformanceRunner()
+    let process = try runner.run(command: command, arguments: commandArgs)
+    process.waitUntilExit()
+    // TODO: Emit collected performance metrics here.
+  }
+}


### PR DESCRIPTION
## Summary
- add WrkstrmPerformance executable target and runner scaffolding for monitoring subprocesses
- document performance hypothesis workflow in AGENTS and AGENCY guidelines

## Testing
- `swift format -i -r -p Sources/WrkstrmPerformance`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6893248fc01c83339cdcab885e96faa9