### PR TITLE
refactor: replace exposure level API with level masks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ targets: [
    Logging is suppressed to `.critical` messages by default. Set a global minimum level during application startup to expose additional logs. The global setting is clamped by each logger's `maxExposureLevel`, requiring libraries to opt in before emitting more verbose messages:
 
    ```swift
-   Log.limitExposure(to: .warning)
+   Log.enableLoggingLevels(levelMask: .threshold(.warning))
    
    // Inspect how far this logger is willing to expose messages
    print(logger.maxExposureLevel) // .info
@@ -104,7 +104,7 @@ targets: [
    }
    ```
 
-   The global limit is configured via `Log.limitExposure`. Each logger exposes its
+   The global limit is configured via `Log.enableLoggingLevels`. Each logger exposes its
    opt-in ceiling through `maxExposureLevel`, ensuring verbose logs are only emitted
    when both the global and per-logger limits allow. When raising the global limit,
    compare it with each logger's `maxExposureLevel` to avoid surfacing unintended

--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -12,7 +12,7 @@ struct WrkstrmLogTests {
   @Test
   func swiftLoggerReuse() {
     Log._reset()
-    Log.limitExposure(to: .trace)
+    Log.enableLoggingLevels(levelMask: .threshold(.trace))
     let log = Log(style: .swift, exposure: .trace, options: [.prod])
     log.info("first")
     #expect(Log._swiftLoggerCount == 1)
@@ -41,7 +41,7 @@ struct WrkstrmLogTests {
 
   @Test
   func pathEncoding() {
-    Log.limitExposure(to: .trace)
+    Log.enableLoggingLevels(levelMask: .threshold(.trace))
     let logger = Log(system: "Test", category: "Encoding", style: .print, exposure: .trace)
     logger.info("Testing path", file: "/tmp/Some Folder/File Name.swift")
     #expect(true)
@@ -50,7 +50,7 @@ struct WrkstrmLogTests {
   @Test
   func disabledProducesNoLoggers() {
     Log._reset()
-    Log.limitExposure(to: .trace)
+    Log.enableLoggingLevels(levelMask: .threshold(.trace))
     Log.disabled.info("silence")
     #expect(Log._swiftLoggerCount == 0)
   }
@@ -58,7 +58,7 @@ struct WrkstrmLogTests {
   @Test
   func logLevelFiltersMessages() {
     Log._reset()
-    Log.limitExposure(to: .trace)
+    Log.enableLoggingLevels(levelMask: .threshold(.trace))
     let log = Log(style: .swift, level: .error, exposure: .trace, options: [.prod])
     log.info("ignored")
     #expect(Log._swiftLoggerCount == 0)
@@ -67,11 +67,11 @@ struct WrkstrmLogTests {
   @Test
   func exposureLimitFiltersMessages() {
     Log._reset()
-    Log.limitExposure(to: .warning)
+    Log.enableLoggingLevels(levelMask: .threshold(.warning))
     let log = Log(style: .swift, exposure: .trace, options: [.prod])
     log.info("suppressed")
     #expect(Log._swiftLoggerCount == 0)
-    Log.limitExposure(to: .trace)
+    Log.enableLoggingLevels(levelMask: .threshold(.trace))
     log.info("logged")
     #expect(Log._swiftLoggerCount == 1)
   }
@@ -79,7 +79,7 @@ struct WrkstrmLogTests {
   @Test
   func loggerExposureLimitRespected() {
     Log._reset()
-    Log.limitExposure(to: .trace)
+    Log.enableLoggingLevels(levelMask: .threshold(.trace))
     let log = Log(style: .swift, exposure: .error, options: [.prod])
     #expect(log.maxExposureLevel == .error)
     log.info("suppressed")
@@ -94,7 +94,7 @@ struct WrkstrmLogTests {
     let log = Log(style: .swift, level: .trace, options: [.prod])
     log.error("suppressed")
     #expect(Log._swiftLoggerCount == 0)
-    Log.limitExposure(to: .trace)
+    Log.enableLoggingLevels(levelMask: .threshold(.trace))
     #expect(log.maxExposureLevel == .critical)
     log.error("still suppressed")
     #expect(Log._swiftLoggerCount == 0)
@@ -104,7 +104,7 @@ struct WrkstrmLogTests {
     @Test
     func overrideLevelAdjustsLoggingInDebug() {
       Log._reset()
-      Log.limitExposure(to: .trace)
+      Log.enableLoggingLevels(levelMask: .threshold(.trace))
       let log = Log(style: .swift, level: .error, exposure: .trace, options: [.prod])
       log.info("suppressed")
       #expect(Log._swiftLoggerCount == 0)
@@ -116,7 +116,7 @@ struct WrkstrmLogTests {
     @Test
     func overrideLevelNoEffectInRelease() {
       Log._reset()
-      Log.limitExposure(to: .trace)
+      Log.enableLoggingLevels(levelMask: .threshold(.trace))
       let log = Log(style: .swift, level: .error, exposure: .trace, options: [.prod])
       log.info("suppressed")
       #expect(Log._swiftLoggerCount == 0)
@@ -136,7 +136,7 @@ struct WrkstrmLogTests {
     @Test
     func defaultLoggerDisabledInRelease() {
       Log._reset()
-      Log.limitExposure(to: .trace)
+      Log.enableLoggingLevels(levelMask: .threshold(.trace))
       let log = Log()
       log.info("silence")
       #expect(log.style == .disabled)
@@ -146,7 +146,7 @@ struct WrkstrmLogTests {
     @Test
     func loggerWithProdOptionEnabledInRelease() {
       Log._reset()
-      Log.limitExposure(to: .trace)
+      Log.enableLoggingLevels(levelMask: .threshold(.trace))
       let log = Log(style: .swift, exposure: .trace, options: [.prod])
       log.info("hello")
       #expect(log.style == .swift)


### PR DESCRIPTION
## Summary
- remove SwiftLog level-based exposure API
- support configurable log level masks
- update tests and docs for new API

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68943ab1f2b083338054212f43522296