### PR TITLE
Document test cases

### DIFF
--- a/Tests/WrkstrmLogTests/LevelExtensionsTests.swift
+++ b/Tests/WrkstrmLogTests/LevelExtensionsTests.swift
@@ -9,6 +9,7 @@ import Testing
 
 @Suite("Logging.Level extensions", .serialized)
 struct LevelExtensionsTests {
+  /// Ensures each logging level maps to the expected emoji.
   @Test
   func emojiMapping() {
     #expect(Logging.Logger.Level.trace.emoji == "🔍")
@@ -21,6 +22,7 @@ struct LevelExtensionsTests {
   }
 
   #if canImport(os)
+    /// Verifies that logging levels convert to the correct `OSLogType` values.
     @Test
     func osLogTypeMapping() {
       #expect(Logging.Logger.Level.trace.toOSType == .debug)

--- a/Tests/WrkstrmLogTests/OSLoggerTests.swift
+++ b/Tests/WrkstrmLogTests/OSLoggerTests.swift
@@ -5,6 +5,7 @@
 
   @Suite("OSLogger", .serialized)
   struct OSLoggerTests {
+    /// Confirms that an `OSLogger` instance is reused across mutations.
     @Test
     func osLoggerReuse() {
       Log._reset()
@@ -19,6 +20,7 @@
       #expect(Log._osLoggerCount == 1)
     }
 
+    /// Ensures `.prod` loggers still record messages at allowed levels.
     @Test
     func logLevelWorksInProd() {
       Log._reset()

--- a/Tests/WrkstrmLogTests/ProcessInfoXcodeTests.swift
+++ b/Tests/WrkstrmLogTests/ProcessInfoXcodeTests.swift
@@ -11,6 +11,7 @@ import Testing
 
 @Suite("ProcessInfo Xcode detection", .serialized)
 struct ProcessInfoXcodeTests {
+  /// Temporarily sets an environment variable, returning a closure to restore it.
   func withEnv(_ key: String, value: String?) -> () -> Void {
     let old = getenv(key).map { String(cString: $0) }
     if let value {
@@ -27,6 +28,7 @@ struct ProcessInfoXcodeTests {
     }
   }
 
+  /// Detects the Xcode environment via the bundle identifier indicator.
   @Test
   func detectsBundleIdentifier() {
     let restore = withEnv("__CFBundleIdentifier", value: "com.apple.dt.Xcode")
@@ -34,6 +36,7 @@ struct ProcessInfoXcodeTests {
     #expect(ProcessInfo.inXcodeEnvironment)
   }
 
+  /// Detects Xcode presence using the `DYLD_LIBRARY_PATH` variable.
   @Test
   func detectsDyldLibraryPath() {
     let restoreCFBundle = withEnv("__CFBundleIdentifier", value: nil)
@@ -43,6 +46,7 @@ struct ProcessInfoXcodeTests {
     #expect(ProcessInfo.inXcodeEnvironment)
   }
 
+  /// Detects Xcode presence using the `DYLD_FRAMEWORK_PATH` variable.
   @Test
   func detectsDyldFrameworkPath() {
     let restoreCFBundle = withEnv("__CFBundleIdentifier", value: nil)
@@ -54,6 +58,7 @@ struct ProcessInfoXcodeTests {
     #expect(ProcessInfo.inXcodeEnvironment)
   }
 
+  /// Confirms the detection returns false when no Xcode indicators are present.
   @Test
   func returnsFalseWhenNoIndicators() {
     let restoreCFBundle = withEnv("__CFBundleIdentifier", value: nil)

--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -4,11 +4,13 @@ import Testing
 
 @Suite("WrkstrmLog", .serialized)
 struct WrkstrmLogTests {
+  /// A trivial test to confirm the test suite executes.
   @Test
   func example() {
     #expect(true)
   }
 
+  /// Verifies that a single Swift logger instance is reused after mutation.
   @Test
   func swiftLoggerReuse() {
     Log._reset()
@@ -23,6 +25,7 @@ struct WrkstrmLogTests {
     #expect(Log._swiftLoggerCount == 1)
   }
 
+  /// Confirms hashing ignores mutable properties that do not affect identity.
   @Test
   func hashingIgnoresMutableProperties() {
     let log = Log(system: "sys", category: "cat")
@@ -39,6 +42,7 @@ struct WrkstrmLogTests {
     #expect(original == mutatedHash)
   }
 
+  /// Ensures file paths with spaces are encoded and logged correctly.
   @Test
   func pathEncoding() {
     Log.limitExposure(to: .trace)
@@ -47,6 +51,7 @@ struct WrkstrmLogTests {
     #expect(true)
   }
 
+  /// Guarantees disabled loggers do not create underlying logger instances.
   @Test
   func disabledProducesNoLoggers() {
     Log._reset()
@@ -55,6 +60,7 @@ struct WrkstrmLogTests {
     #expect(Log._swiftLoggerCount == 0)
   }
 
+  /// Checks that increasing global exposure filters messages below the threshold.
   @Test
   func exposureLimitFiltersMessages() {
     Log._reset()
@@ -67,6 +73,7 @@ struct WrkstrmLogTests {
     #expect(Log._swiftLoggerCount == 1)
   }
 
+  /// Verifies a logger's exposure limit is respected even when global limits differ.
   @Test
   func loggerExposureLimitRespected() {
     Log._reset()
@@ -79,6 +86,7 @@ struct WrkstrmLogTests {
     #expect(Log._swiftLoggerCount == 1)
   }
 
+  /// Ensures raising the global exposure level does not override a logger's limit.
   @Test
   func globalExposureIncreaseDoesNotOverrideLoggerLimit() {
     Log._reset()
@@ -92,6 +100,7 @@ struct WrkstrmLogTests {
   }
 
   #if DEBUG
+    /// Validates that overriding the level adjusts logging in debug builds.
     @Test
     func overrideLevelAdjustsLoggingInDebug() {
       Log._reset()
@@ -106,12 +115,14 @@ struct WrkstrmLogTests {
   #endif
 
   #if DEBUG
+    /// Confirms the default logger remains enabled in debug builds.
     @Test
     func defaultLoggerNotDisabledInDebug() {
       let log = Log()
       #expect(log.style != .disabled)
     }
   #else
+    /// Verifies the default logger is disabled in release builds.
     @Test
     func defaultLoggerDisabledInRelease() {
       Log._reset()
@@ -122,6 +133,7 @@ struct WrkstrmLogTests {
       #expect(Log._swiftLoggerCount == 0)
     }
 
+    /// Ensures a logger with the `.prod` option remains enabled in release builds.
     @Test
     func loggerWithProdOptionEnabledInRelease() {
       Log._reset()


### PR DESCRIPTION
## Summary
- clarify emoji and OSLog type mappings in logging level extension tests
- document OS logger reuse and production-level logging behavior
- describe environment-based detection and logger behavior across WrkstrmLog tests

## Testing
- `swift test` *(fails: invalid redeclaration of 'disabled')*

------
https://chatgpt.com/codex/tasks/task_e_6895637b34c4833386f3c6b81710442a