### PR TITLE
Introduce writable global exposure property

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ targets: [
    Logging is suppressed to `.critical` messages by default. Set a global minimum level during application startup to expose additional logs. The global setting is clamped by each logger's `maxExposureLevel`, requiring libraries to opt in before emitting more verbose messages:
 
    ```swift
-   Log.limitExposure(to: .warning)
+   Log.globalExposureLevel = .warning
    
    // Inspect how far this logger is willing to expose messages
    print(logger.maxExposureLevel) // .info
@@ -104,7 +104,7 @@ targets: [
    }
    ```
 
-   The global limit is configured via `Log.limitExposure`. Each logger exposes its
+   The global limit is configured via `Log.globalExposureLevel`. Each logger exposes its
    opt-in ceiling through `maxExposureLevel`, ensuring verbose logs are only emitted
    when both the global and per-logger limits allow. When raising the global limit,
    compare it with each logger's `maxExposureLevel` to avoid surfacing unintended

--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -14,7 +14,7 @@ struct WrkstrmLogTests {
   @Test
   func swiftLoggerReuse() {
     Log._reset()
-    Log.limitExposure(to: .trace)
+    Log.globalExposureLevel = .trace
     let log = Log(style: .swift, exposure: .trace, options: [.prod])
     log.info("first")
     #expect(Log._swiftLoggerCount == 1)
@@ -45,7 +45,7 @@ struct WrkstrmLogTests {
   /// Ensures file paths with spaces are encoded and logged correctly.
   @Test
   func pathEncoding() {
-    Log.limitExposure(to: .trace)
+    Log.globalExposureLevel = .trace
     let logger = Log(system: "Test", category: "Encoding", style: .print, exposure: .trace)
     logger.info("Testing path", file: "/tmp/Some Folder/File Name.swift")
     #expect(true)
@@ -55,7 +55,7 @@ struct WrkstrmLogTests {
   @Test
   func disabledProducesNoLoggers() {
     Log._reset()
-    Log.limitExposure(to: .trace)
+    Log.globalExposureLevel = .trace
     Log.disabled.info("silence")
     #expect(Log._swiftLoggerCount == 0)
   }
@@ -64,11 +64,11 @@ struct WrkstrmLogTests {
   @Test
   func exposureLimitFiltersMessages() {
     Log._reset()
-    Log.limitExposure(to: .warning)
+    Log.globalExposureLevel = .warning
     let log = Log(style: .swift, exposure: .trace, options: [.prod])
     log.info("suppressed")
     #expect(Log._swiftLoggerCount == 0)
-    Log.limitExposure(to: .trace)
+    Log.globalExposureLevel = .trace
     log.info("logged")
     #expect(Log._swiftLoggerCount == 1)
   }
@@ -77,7 +77,7 @@ struct WrkstrmLogTests {
   @Test
   func loggerExposureLimitRespected() {
     Log._reset()
-    Log.limitExposure(to: .trace)
+    Log.globalExposureLevel = .trace
     let log = Log(style: .swift, exposure: .error, options: [.prod])
     #expect(log.maxExposureLevel == .error)
     log.info("suppressed")
@@ -93,7 +93,7 @@ struct WrkstrmLogTests {
     let log = Log(style: .swift, options: [.prod])
     log.error("suppressed")
     #expect(Log._swiftLoggerCount == 0)
-    Log.limitExposure(to: .trace)
+    Log.globalExposureLevel = .trace
     #expect(log.maxExposureLevel == .critical)
     log.error("still suppressed")
     #expect(Log._swiftLoggerCount == 0)
@@ -104,7 +104,7 @@ struct WrkstrmLogTests {
     @Test
     func overrideLevelAdjustsLoggingInDebug() {
       Log._reset()
-      Log.limitExposure(to: .trace)
+      Log.globalExposureLevel = .trace
       let log = Log(style: .swift, exposure: .trace, options: [.prod])
       log.info("suppressed")
       #expect(Log._swiftLoggerCount == 1)
@@ -126,7 +126,7 @@ struct WrkstrmLogTests {
     @Test
     func defaultLoggerDisabledInRelease() {
       Log._reset()
-      Log.limitExposure(to: .trace)
+      Log.globalExposureLevel = .trace
       let log = Log()
       log.info("silence")
       #expect(log.style == .disabled)
@@ -137,7 +137,7 @@ struct WrkstrmLogTests {
     @Test
     func loggerWithProdOptionEnabledInRelease() {
       Log._reset()
-      Log.limitExposure(to: .trace)
+      Log.globalExposureLevel = .trace
       let log = Log(style: .swift, exposure: .trace, options: [.prod])
       log.info("hello")
       #expect(log.style == .swift)


### PR DESCRIPTION
## Summary
- replace `limitExposure` with writable `globalExposureLevel` property
- remove legacy `limitExposure` and `globalLogExposureLevel` APIs
- update tests and docs to property syntax

## Testing
- `swift format -i -r -p Sources/WrkstrmLog/Log.swift Tests/WrkstrmLogTests/WrkstrmLogTests.swift`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68959efd1d348333a1444c43f2342c02