### PR TITLE
Clarify exposure level terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ targets: [
 
 2. **Initialize a logger** ⚙️
 
-   Create a logger with your system and category. By default, each logger suppresses messages below the `.critical` level. Set an `exposure` limit to allow additional levels:
+   Create a logger with your system and category. By default, each logger suppresses messages below the `.critical` level. Set a `maxExposureLevel` to allow additional levels:
 
    ```swift
-   let logger = Log(system: "YourSystem", category: "YourCategory", exposure: .info)
+   let logger = Log(system: "YourSystem", category: "YourCategory", maxExposureLevel: .info)
    ```
 
 3. **Log messages** 📝

--- a/Sources/WrkstrmLog/Log+Shared.swift
+++ b/Sources/WrkstrmLog/Log+Shared.swift
@@ -9,7 +9,7 @@ extension Log {
   /// Log.shared.info("Application started")
   /// ```
   public nonisolated(unsafe) static var shared =
-    Log(system: "wrkstrm", category: "shared", exposure: .trace)
+    Log(system: "wrkstrm", category: "shared", maxExposureLevel: .trace)
   {
     didSet {
       #if DEBUG

--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -135,10 +135,10 @@ public struct Log: Hashable, @unchecked Sendable {
   public let options: Options
 
   /// Internal maximum log level this logger is permitted to expose.
-  private let exposureLimit: Logging.Logger.Level
+  private let maxExposureLevelLimit: Logging.Logger.Level
 
   /// The maximum log level this logger can emit.
-  public var maxExposureLevel: Logging.Logger.Level { exposureLimit }
+  public var maxExposureLevel: Logging.Logger.Level { maxExposureLevelLimit }
 
   #if canImport(os)
     @usableFromInline static let defaultStyle: Style = .os
@@ -248,7 +248,7 @@ public struct Log: Hashable, @unchecked Sendable {
     ///   - style: The logging style used by the logger (`.print`, `.os`, `.swift`,
     ///     `.disabled`). Defaults to `.os`.
     ///   - level: The minimum log level that will be logged. Defaults to `.info`.
-    ///   - exposure: The maximum log level permitted for this logger. Defaults to `.critical`.
+    ///   - maxExposureLevel: The maximum log level permitted for this logger. Defaults to `.critical`.
     ///   - options: Configuration options for the logger. Use `.prod` to keep the
     ///     logger active in production. Defaults to an empty set.
     ///
@@ -260,13 +260,13 @@ public struct Log: Hashable, @unchecked Sendable {
       system: String = "",
       category: String = "",
       style: Style = ProcessInfo.inXcodeEnvironment ? defaultStyle : .print,
-      exposure: Logging.Logger.Level = .critical,
+      maxExposureLevel: Logging.Logger.Level = .critical,
       options: Options = []
     ) {
       self.system = system
       self.category = category
       self.options = options
-      self.exposureLimit = exposure
+      self.maxExposureLevelLimit = maxExposureLevel
       #if DEBUG
         self.style = style
       #else
@@ -283,7 +283,7 @@ public struct Log: Hashable, @unchecked Sendable {
     ///   - style: The logging style used by the logger (`.print`, `.swift`, `.disabled`).
     ///     Defaults to `.swift`.
     ///   - level: The minimum log level that will be logged. Defaults to `.info`.
-    ///   - exposure: The maximum log level permitted for this logger. Defaults to `.critical`.
+    ///   - maxExposureLevel: The maximum log level permitted for this logger. Defaults to `.critical`.
     ///   - options: Configuration options for the logger. Use `.prod` to keep the
     ///     logger active in production. Defaults to an empty set.
     ///
@@ -295,13 +295,13 @@ public struct Log: Hashable, @unchecked Sendable {
       system: String = "",
       category: String = "",
       style: Style = ProcessInfo.inXcodeEnvironment ? defaultStyle : .print,
-      exposure: Logging.Logger.Level = .critical,
+      maxExposureLevel: Logging.Logger.Level = .critical,
       options: Options = []
     ) {
       self.system = system
       self.category = category
       self.options = options
-      self.exposureLimit = exposure
+      self.maxExposureLevelLimit = maxExposureLevel
       #if DEBUG
         self.style = style
       #else
@@ -317,7 +317,7 @@ public struct Log: Hashable, @unchecked Sendable {
     lhs.system == rhs.system && lhs.category == rhs.category
       && lhs.style == rhs.style
       && lhs.options == rhs.options
-      && lhs.exposureLimit == rhs.exposureLimit
+      && lhs.maxExposureLevelLimit == rhs.maxExposureLevelLimit
   }
 
   public func hash(into hasher: inout Hasher) {
@@ -325,7 +325,7 @@ public struct Log: Hashable, @unchecked Sendable {
     hasher.combine(category)
     hasher.combine(style)
     hasher.combine(options)
-    hasher.combine(exposureLimit)
+    hasher.combine(maxExposureLevelLimit)
   }
 
   /// Formats the function name to fit within the specified maximum length.
@@ -487,8 +487,8 @@ public struct Log: Hashable, @unchecked Sendable {
       // exposure setting and the logger's own limit.
       let clampedExposure =
         globalExposure.naturalIntegralValue
-          <= self.exposureLimit.naturalIntegralValue
-        ? globalExposure : self.exposureLimit
+          <= self.maxExposureLevelLimit.naturalIntegralValue
+        ? globalExposure : self.maxExposureLevelLimit
       resolvedMask.formIntersection(.threshold(clampedExposure))
       guard resolvedMask.contains(.single(level)) else { return }
       let effectiveLevel = resolvedMask.minimumLevel
@@ -499,8 +499,8 @@ public struct Log: Hashable, @unchecked Sendable {
       // exposure setting and the logger's own limit.
       let clampedExposure =
         globalExposure.naturalIntegralValue
-          <= self.exposureLimit.naturalIntegralValue
-        ? globalExposure : self.exposureLimit
+          <= self.maxExposureLevelLimit.naturalIntegralValue
+        ? globalExposure : self.maxExposureLevelLimit
       let effectiveLevel: Logging.Logger.Level
       if clampedExposure > configuredLevel {
         effectiveLevel = clampedExposure
@@ -585,7 +585,7 @@ extension Log {
     logLevel: Logging.Logger.Level,
     completion: ((Log) throws -> Void)?
   ) throws {
-    if logLevel <= self.exposureLimit
+    if logLevel <= self.maxExposureLevelLimit
       && maxExposureLevel <= Log.globalExposureLevel
     {
       info("Log Level Enabled: \(logLevel)")

--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -15,7 +15,7 @@ struct WrkstrmLogTests {
   func swiftLoggerReuse() {
     Log._reset()
     Log.globalExposureLevel = .trace
-    let log = Log(style: .swift, exposure: .trace, options: [.prod])
+    let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     log.info("first")
     #expect(Log._swiftLoggerCount == 1)
 
@@ -46,7 +46,7 @@ struct WrkstrmLogTests {
   @Test
   func pathEncoding() {
     Log.globalExposureLevel = .trace
-    let logger = Log(system: "Test", category: "Encoding", style: .print, exposure: .trace)
+    let logger = Log(system: "Test", category: "Encoding", style: .print, maxExposureLevel: .trace)
     logger.info("Testing path", file: "/tmp/Some Folder/File Name.swift")
     #expect(true)
   }
@@ -65,7 +65,7 @@ struct WrkstrmLogTests {
   func exposureLimitFiltersMessages() {
     Log._reset()
     Log.globalExposureLevel = .warning
-    let log = Log(style: .swift, exposure: .trace, options: [.prod])
+    let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     log.info("suppressed")
     #expect(Log._swiftLoggerCount == 0)
     Log.globalExposureLevel = .trace
@@ -73,12 +73,12 @@ struct WrkstrmLogTests {
     #expect(Log._swiftLoggerCount == 1)
   }
 
-  /// Verifies a logger's exposure limit is respected even when global limits differ.
+  /// Verifies a logger's max exposure level is respected even when global limits differ.
   @Test
-  func loggerExposureLimitRespected() {
+  func loggerMaxExposureLevelRespected() {
     Log._reset()
     Log.globalExposureLevel = .trace
-    let log = Log(style: .swift, exposure: .error, options: [.prod])
+    let log = Log(style: .swift, maxExposureLevel: .error, options: [.prod])
     #expect(log.maxExposureLevel == .error)
     log.info("suppressed")
     #expect(Log._swiftLoggerCount == 0)
@@ -86,9 +86,9 @@ struct WrkstrmLogTests {
     #expect(Log._swiftLoggerCount == 1)
   }
 
-  /// Ensures raising the global exposure level does not override a logger's limit.
+  /// Ensures raising the global exposure level does not override a logger's max exposure level.
   @Test
-  func globalExposureIncreaseDoesNotOverrideLoggerLimit() {
+  func globalExposureIncreaseDoesNotOverrideLoggerMax() {
     Log._reset()
     let log = Log(style: .swift, options: [.prod])
     log.error("suppressed")
@@ -105,7 +105,7 @@ struct WrkstrmLogTests {
     func overrideLevelAdjustsLoggingInDebug() {
       Log._reset()
       Log.globalExposureLevel = .trace
-      let log = Log(style: .swift, exposure: .trace, options: [.prod])
+      let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
       log.info("suppressed")
       #expect(Log._swiftLoggerCount == 1)
       Log.overrideLevel(for: log, to: .debug)
@@ -138,7 +138,7 @@ struct WrkstrmLogTests {
     func loggerWithProdOptionEnabledInRelease() {
       Log._reset()
       Log.globalExposureLevel = .trace
-      let log = Log(style: .swift, exposure: .trace, options: [.prod])
+      let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
       log.info("hello")
       #expect(log.style == .swift)
       #expect(Log._swiftLoggerCount == 1)


### PR DESCRIPTION
## Summary
- Rename `Log` initializer's `exposure` parameter to `maxExposureLevel` and back it with `maxExposureLevelLimit`
- Update shared logger, README examples, and tests to use the new parameter name

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6895cac782d88333a9d8c73c3d81b6c8