### PR TITLE
Refine log level enablement API

### DIFF
--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -573,24 +573,23 @@ public struct Log: Hashable, @unchecked Sendable {
 }
 
 extension Log {
-  /// Evaluates whether the logger should log a message at the specified log level and, if so, invokes the provided completion closure.
+  /// Determines whether logging is enabled for the provided level based on
+  /// both the logger's `maxExposureLevel` and the global exposure level.
   ///
-  /// The function checks if the logger's current level matches the specified log level and whether the logger's maximum exposure level
-  /// is less than or equal to the global log exposure level. If both conditions are met, it calls the completion closure with `self`.
+  /// - Parameter level: The level to evaluate.
+  /// - Returns: `true` if logging at the specified level is enabled.
+  public func isEnabled(for level: Logging.Logger.Level) -> Bool {
+    level >= self.maxExposureLevel && level >= Log.globalExposureLevel
+  }
+
+  /// Invokes `body` only when logging is enabled for the given level.
   ///
   /// - Parameters:
-  ///   - logLevel: The log level to check against the logger's configured level.
-  ///   - completion: A closure to invoke if the logger should log at the given level. Receives the logger instance as a parameter.
-  public func shouldLog(
-    logLevel: Logging.Logger.Level,
-    completion: ((Log) throws -> Void)?
-  ) throws {
-    if logLevel <= self.exposureLimit
-      && maxExposureLevel <= Log.globalExposureLevel
-    {
-      info("Log Level Enabled: \(logLevel)")
-      try completion?(self)
-    }
+  ///   - level: The level to evaluate.
+  ///   - body: A closure executed when logging is enabled for `level`.
+  public func ifEnabled(for level: Logging.Logger.Level, _ body: (Log) throws -> Void) rethrows {
+    guard isEnabled(for: level) else { return }
+    try body(self)
   }
 }
 

--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -86,6 +86,29 @@ struct WrkstrmLogTests {
     #expect(Log._swiftLoggerCount == 1)
   }
 
+  /// Confirms `isEnabled(for:)` evaluates both global and logger limits.
+  @Test
+  func isEnabledRespectsExposureLimits() {
+    Log._reset()
+    Log.globalExposureLevel = .warning
+    let log = Log(style: .swift, exposure: .info, options: [.prod])
+    #expect(log.isEnabled(for: .info) == false)
+    #expect(log.isEnabled(for: .warning) == true)
+  }
+
+  /// Validates `ifEnabled(for:_:)` executes the closure only when enabled.
+  @Test
+  func ifEnabledExecutesConditionally() {
+    Log._reset()
+    Log.globalExposureLevel = .warning
+    let log = Log(style: .swift, exposure: .trace, options: [.prod])
+    var executed = false
+    log.ifEnabled(for: .debug) { _ in executed = true }
+    #expect(executed == false)
+    log.ifEnabled(for: .error) { _ in executed = true }
+    #expect(executed == true)
+  }
+
   /// Ensures raising the global exposure level does not override a logger's limit.
   @Test
   func globalExposureIncreaseDoesNotOverrideLoggerLimit() {


### PR DESCRIPTION
## Summary
- replace `shouldLog` with `isEnabled(for:)` and added `ifEnabled(for:_:)`
- remove implicit log emission when checking level
- cover new API behavior with unit tests

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6895cad615f88333b1945b5d0dd9399e