### PR TITLE
Add logging API tutorial

### DIFF
--- a/Documentation/LoggingAPIs.docc/Tutorials/LoggingAPIs.tutorial
+++ b/Documentation/LoggingAPIs.docc/Tutorials/LoggingAPIs.tutorial
@@ -1,0 +1,50 @@
+@Tutorial(time: 15) {
+  @Intro(title: "Logging with WrkstrmLog") {
+    Learn how to configure and emit log messages with WrkstrmLog.
+  }
+
+  @Section(title: "Create a Logger") {
+    Instantiate a logger with a system and category to organize messages.
+
+    @ContentAndMedia {
+    ```swift
+    import WrkstrmLog
+
+    let logger = Log(system: "ExampleApp", category: "Networking")
+    ```
+    }
+  }
+
+  @Section(title: "Control Exposure Level") {
+    WrkstrmLog hides messages more verbose than `critical` by default. Raise
+    the global exposure level to view additional details.
+
+    @ContentAndMedia {
+    ```swift
+    Log.globalExposureLevel = .debug
+    ```
+    }
+  }
+
+  @Section(title: "Choose a Logging Style") {
+    Select the output style appropriate for your platform or environment.
+
+    @ContentAndMedia {
+    ```swift
+    let osLogger = Log(system: "ExampleApp", category: "Startup", style: .os)
+    let printLogger = Log(system: "ExampleApp", category: "Startup", style: .print)
+    ```
+    }
+  }
+
+  @Section(title: "Record Messages") {
+    Each logger provides methods for standard log levels.
+
+    @ContentAndMedia {
+    ```swift
+    logger.notice("Request finished")
+    logger.error("Request failed: \(error)")
+    ```
+    }
+  }
+}

--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -589,7 +589,6 @@ extension Log {
   ///   - body: A closure executed when logging is enabled for `level`.
   public func ifEnabled(for level: Logging.Logger.Level, _ body: (Log) throws -> Void) rethrows {
     guard isEnabled(for: level) else { return }
-    info("Log Level Enabled: \(logLevel)")
     try body(self)
   }
 }


### PR DESCRIPTION
## Summary
- add DoCC tutorial covering WrkstrmLog logging APIs
- drop stray debug log call from `ifEnabled`

## Testing
- `swift test` *(fails: extra argument 'exposure' in call)*

------
https://chatgpt.com/codex/tasks/task_e_6895d552439483338bd419d8a1d69bf3