### PR TITLE
chore: record 2.0.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [2.0.0]
 ### Added
 - Introduce a global exposure limit to restrict logging output across libraries. The limit
   defaults to `.critical` and must be configured at startup to enable more verbose logging.


### PR DESCRIPTION
## Summary
- move unreleased notes to 2.0.0 section

## Testing
- `swift test` *(fails: extra argument 'exposure' in call)*

------
https://chatgpt.com/codex/tasks/task_e_6896a53ead2083338faf7463a635e9f9