### PR TITLE
Remove OSLog shims and confine platform guards

### DIFF
--- a/Tests/WrkstrmLogTests/OSLoggerTests.swift
+++ b/Tests/WrkstrmLogTests/OSLoggerTests.swift
@@ -1,6 +1,7 @@
+import Testing
+
 #if canImport(os)
   import os
-  import Testing
   @testable import WrkstrmLog
 
   @Suite("OSLogger", .serialized)
@@ -9,7 +10,8 @@
     @Test
     func osLoggerReuse() {
       Log._reset()
-      let log = Log()
+      Log.globalExposureLevel = .trace
+      let log = Log(style: .os, maxExposureLevel: .trace, options: [.prod])
       #expect(Log._osLoggerCount == 0)
       log.info("first")
       #expect(Log._osLoggerCount == 1)
@@ -24,7 +26,8 @@
     @Test
     func logLevelWorksInProd() {
       Log._reset()
-      let log = Log(style: .os, options: [.prod])
+      Log.globalExposureLevel = .trace
+      let log = Log(style: .os, maxExposureLevel: .trace, options: [.prod])
       log.info("not ignored")
       #expect(Log._osLoggerCount == 1)
     }

--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -4,12 +4,6 @@ import Testing
 
 @Suite("WrkstrmLog", .serialized)
 struct WrkstrmLogTests {
-  /// A trivial test to confirm the test suite executes.
-  @Test
-  func example() {
-    #expect(true)
-  }
-
   /// Verifies that a single Swift logger instance is reused after mutation.
   @Test
   func swiftLoggerReuse() {
@@ -48,7 +42,7 @@ struct WrkstrmLogTests {
     Log.globalExposureLevel = .trace
     let logger = Log(system: "Test", category: "Encoding", style: .print, maxExposureLevel: .trace)
     logger.info("Testing path", file: "/tmp/Some Folder/File Name.swift")
-    #expect(true)
+    #expect(Bool(true))
   }
 
   /// Guarantees disabled loggers do not create underlying logger instances.
@@ -85,13 +79,13 @@ struct WrkstrmLogTests {
     log.error("logged")
     #expect(Log._swiftLoggerCount == 1)
   }
-  
+
   /// Confirms `isEnabled(for:)` evaluates both global and logger limits.
   @Test
   func isEnabledRespectsExposureLimits() {
     Log._reset()
     Log.globalExposureLevel = .warning
-    let log = Log(style: .swift, exposure: .info, options: [.prod])
+    let log = Log(style: .swift, maxExposureLevel: .info, options: [.prod])
     #expect(log.isEnabled(for: .info) == false)
     #expect(log.isEnabled(for: .warning) == true)
   }
@@ -101,7 +95,7 @@ struct WrkstrmLogTests {
   func ifEnabledExecutesConditionally() {
     Log._reset()
     Log.globalExposureLevel = .warning
-    let log = Log(style: .swift, exposure: .trace, options: [.prod])
+    let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     var executed = false
     log.ifEnabled(for: .debug) { _ in executed = true }
     #expect(executed == false)


### PR DESCRIPTION
## Summary
- drop the Linux-only `os` target and its OSLog shim to avoid masking platform differences
- keep most of `Log` outside `#if canImport(os)` by isolating only `OSLog` storage and using a single cross-platform initializer
- gate OS logging tests and `OSLogType` mapping behind `#if canImport(os)`

## Testing
- `swift format -i -r -p Package.swift Sources/WrkstrmLog/Log.swift Tests/WrkstrmLogTests/OSLoggerTests.swift Tests/WrkstrmLogTests/LevelExtensionsTests.swift`
- `swift format lint Package.swift Sources/WrkstrmLog/Log.swift Tests/WrkstrmLogTests/OSLoggerTests.swift Tests/WrkstrmLogTests/LevelExtensionsTests.swift`
- `swiftlint lint Sources Tests`
- `swift test --enable-code-coverage --parallel`


------
https://chatgpt.com/codex/tasks/task_e_6896a56374508333a09ab275c7944233