### PR TITLE
Add notice, warning, and debug logging helpers

### DIFF
--- a/Documentation/LoggingAPIs.docc/Tutorials/LoggingAPIs.tutorial
+++ b/Documentation/LoggingAPIs.docc/Tutorials/LoggingAPIs.tutorial
@@ -43,7 +43,11 @@
 
     @ContentAndMedia {
     ```swift
+    logger.verbose("Request started")
+    logger.debug("Parsing response")
+    logger.info("Request progress")
     logger.notice("Request finished")
+    logger.warning("Slow response")
     logger.error("Request failed: \(error)")
     ```
     }

--- a/Documentation/LoggingAPIs.docc/Tutorials/LoggingAPIs.tutorial
+++ b/Documentation/LoggingAPIs.docc/Tutorials/LoggingAPIs.tutorial
@@ -43,12 +43,12 @@
 
     @ContentAndMedia {
     ```swift
-    logger.verbose("Request started")
-    logger.debug("Parsing response")
-    logger.info("Request progress")
-    logger.notice("Request finished")
-    logger.warning("Slow response")
-    logger.error("Request failed: \(error)")
+    logger.verbose("Request started")  // 🔍
+    logger.debug("Parsing response")   // 🐞
+    logger.info("Request progress")    // ℹ️
+    logger.notice("Request finished")  // 📝
+    logger.warning("Slow response")    // ⚠️
+    logger.error("Request failed: \(error)") // ❗
     ```
     }
   }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ targets: [
    Log.guard("Critical error")
    ```
 
+   Each level maps to a visual emoji for quick scanning:
+
+   | Level    | Emoji |
+   |----------|:-----:|
+   | trace    | 🔍 |
+   | debug    | 🐞 |
+   | info     | ℹ️ |
+   | notice   | 📝 |
+   | warning  | ⚠️ |
+   | error    | ❗ |
+   | critical | 🚨 |
+
 4. **Disable or enable logging in production** 🔇
 
    Loggers default to `.disabled` in release builds. Use the `.prod` option to keep them active or the `.disabled` style for a silent logger.

--- a/README.md
+++ b/README.md
@@ -60,11 +60,14 @@ targets: [
 
 3. **Log messages** 📝
 
-   Use the provided methods such as `verbose`, `info`, `error`, and `guard`. `verbose` logs are emitted at the debug level.
+   Use the provided methods such as `debug`, `verbose`, `info`, `notice`, `warning`, `error`, and `guard`. `verbose` logs are emitted at the debug level.
 
    ```swift
+   logger.debug("Debug message")
    logger.verbose("Verbose message")
    logger.info("Info message")
+   logger.notice("Notice message")
+   logger.warning("Warning message")
    logger.error("Error message")
    Log.guard("Critical error")
    ```

--- a/Sources/WrkstrmLog/Log+Shared.swift
+++ b/Sources/WrkstrmLog/Log+Shared.swift
@@ -49,6 +49,33 @@ extension Log {
     )
   }
 
+  /// Logs a debug message with the specified parameters.
+  ///
+  /// - Parameters:
+  ///   - describable: The message string to log.
+  ///   - file: The source file where the log message is generated.
+  ///   - function: The name of the function where the log message is generated.
+  ///   - line: The line number in the source file where the log message is generated.
+  ///   - column: The column number in the source file where the log message is generated.
+  ///   - dso: The address of the shared object where the log message is generated.
+  public static func debug(
+    _ describable: Any,
+    file: String = #fileID,
+    function: String = #function,
+    line: UInt = #line,
+    column: UInt = #column,
+    dso: UnsafeRawPointer = #dsohandle,
+  ) {
+    Log.shared.debug(
+      describable,
+      file: file,
+      function: function,
+      line: line,
+      column: column,
+      dso: dso,
+    )
+  }
+
   /// Logs a info message with the specified parameters.
   ///
   /// - Parameters:
@@ -67,6 +94,60 @@ extension Log {
     dso: UnsafeRawPointer = #dsohandle,
   ) {
     Log.shared.info(
+      describable,
+      file: file,
+      function: function,
+      line: line,
+      column: column,
+      dso: dso,
+    )
+  }
+
+  /// Logs a notice message with the specified parameters.
+  ///
+  /// - Parameters:
+  ///   - describable: The message string to log.
+  ///   - file: The source file where the log message is generated.
+  ///   - function: The name of the function where the log message is generated.
+  ///   - line: The line number in the source file where the log message is generated.
+  ///   - column: The column number in the source file where the log message is generated.
+  ///   - dso: The address of the shared object where the log message is generated.
+  public static func notice(
+    _ describable: Any,
+    file: String = #fileID,
+    function: String = #function,
+    line: UInt = #line,
+    column: UInt = #column,
+    dso: UnsafeRawPointer = #dsohandle,
+  ) {
+    Log.shared.notice(
+      describable,
+      file: file,
+      function: function,
+      line: line,
+      column: column,
+      dso: dso,
+    )
+  }
+
+  /// Logs a warning message with the specified parameters.
+  ///
+  /// - Parameters:
+  ///   - describable: The message string to log.
+  ///   - file: The source file where the log message is generated.
+  ///   - function: The name of the function where the log message is generated.
+  ///   - line: The line number in the source file where the log message is generated.
+  ///   - column: The column number in the source file where the log message is generated.
+  ///   - dso: The address of the shared object where the log message is generated.
+  public static func warning(
+    _ describable: Any,
+    file: String = #fileID,
+    function: String = #function,
+    line: UInt = #line,
+    column: UInt = #column,
+    dso: UnsafeRawPointer = #dsohandle,
+  ) {
+    Log.shared.warning(
       describable,
       file: file,
       function: function,

--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -227,6 +227,35 @@ public struct Log: Hashable, @unchecked Sendable {
     )
   }
 
+  /// Logs a debug message with the specified parameters.
+  ///
+  /// - Parameters:
+  ///   - describable: The object or string to log.
+  ///   - file: The source file where the log message is generated.
+  ///   - function: The name of the function where the log message is generated.
+  ///   - line: The line number in the source file where the log message is generated.
+  ///   - column: The column number in the source file where the log message is generated.
+  ///   - dso: The address of the shared object where the log message is generated.
+  public func debug(
+    _ describable: Any,
+    file: String = #fileID,
+    function: String = #function,
+    line: UInt = #line,
+    column: UInt = #column,
+    dso: UnsafeRawPointer = #dsohandle,
+  ) {
+    guard style != .disabled else { return }
+    log(
+      .debug,
+      describable: describable,
+      file: file,
+      function: function,
+      line: line,
+      column: column,
+      dso: dso,
+    )
+  }
+
   /// Logs an informational message with the specified parameters.
   ///
   /// - Parameters:
@@ -247,6 +276,64 @@ public struct Log: Hashable, @unchecked Sendable {
     guard style != .disabled else { return }
     log(
       .info,
+      describable: describable,
+      file: file,
+      function: function,
+      line: line,
+      column: column,
+      dso: dso,
+    )
+  }
+
+  /// Logs a notice message with the specified parameters.
+  ///
+  /// - Parameters:
+  ///   - describable: The object or string to log.
+  ///   - file: The source file where the log message is generated.
+  ///   - function: The name of the function where the log message is generated.
+  ///   - line: The line number in the source file where the log message is generated.
+  ///   - column: The column number in the source file where the log message is generated.
+  ///   - dso: The address of the shared object where the log message is generated.
+  public func notice(
+    _ describable: Any = "",
+    file: String = #fileID,
+    function: String = #function,
+    line: UInt = #line,
+    column: UInt = #column,
+    dso: UnsafeRawPointer = #dsohandle,
+  ) {
+    guard style != .disabled else { return }
+    log(
+      .notice,
+      describable: describable,
+      file: file,
+      function: function,
+      line: line,
+      column: column,
+      dso: dso,
+    )
+  }
+
+  /// Logs a warning message with the specified parameters.
+  ///
+  /// - Parameters:
+  ///   - describable: The object or string to log.
+  ///   - file: The source file where the log message is generated.
+  ///   - function: The name of the function where the log message is generated.
+  ///   - line: The line number in the source file where the log message is generated.
+  ///   - column: The column number in the source file where the log message is generated.
+  ///   - dso: The address of the shared object where the log message is generated.
+  public func warning(
+    _ describable: Any,
+    file: String = #fileID,
+    function: String = #function,
+    line: UInt = #line,
+    column: UInt = #column,
+    dso: UnsafeRawPointer = #dsohandle,
+  ) {
+    guard style != .disabled else { return }
+    log(
+      .warning,
       describable: describable,
       file: file,
       function: function,

--- a/Tests/WrkstrmLogTests/LevelExtensionsTests.swift
+++ b/Tests/WrkstrmLogTests/LevelExtensionsTests.swift
@@ -12,13 +12,18 @@ struct LevelExtensionsTests {
   /// Ensures each logging level maps to the expected emoji.
   @Test
   func emojiMapping() {
-    #expect(Logging.Logger.Level.trace.emoji == "🔍")
-    #expect(Logging.Logger.Level.debug.emoji == "🐞")
-    #expect(Logging.Logger.Level.info.emoji == "ℹ️")
-    #expect(Logging.Logger.Level.notice.emoji == "📝")
-    #expect(Logging.Logger.Level.warning.emoji == "⚠️")
-    #expect(Logging.Logger.Level.error.emoji == "❗")
-    #expect(Logging.Logger.Level.critical.emoji == "🚨")
+    let mappings: [(Logging.Logger.Level, String)] = [
+      (.trace, "🔍"),
+      (.debug, "🐞"),
+      (.info, "ℹ️"),
+      (.notice, "📝"),
+      (.warning, "⚠️"),
+      (.error, "❗"),
+      (.critical, "🚨"),
+    ]
+    for (level, emoji) in mappings {
+      #expect(level.emoji == emoji)
+    }
   }
 
   #if canImport(os)

--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -81,6 +81,45 @@ struct WrkstrmLogTests {
     #expect(Log._swiftLoggerCount == 1)
   }
 
+  /// Validates the debug helper respects exposure limits.
+  @Test
+  func debugHelperRespectsExposure() {
+    Log._reset()
+    Log.globalExposureLevel = .info
+    let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
+    log.debug("suppressed")
+    #expect(Log._swiftLoggerCount == 0)
+    Log.globalExposureLevel = .debug
+    log.debug("logged")
+    #expect(Log._swiftLoggerCount == 1)
+  }
+
+  /// Validates the notice helper respects exposure limits.
+  @Test
+  func noticeHelperRespectsExposure() {
+    Log._reset()
+    Log.globalExposureLevel = .warning
+    let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
+    log.notice("suppressed")
+    #expect(Log._swiftLoggerCount == 0)
+    Log.globalExposureLevel = .notice
+    log.notice("logged")
+    #expect(Log._swiftLoggerCount == 1)
+  }
+
+  /// Validates the warning helper respects exposure limits.
+  @Test
+  func warningHelperRespectsExposure() {
+    Log._reset()
+    Log.globalExposureLevel = .error
+    let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
+    log.warning("suppressed")
+    #expect(Log._swiftLoggerCount == 0)
+    Log.globalExposureLevel = .warning
+    log.warning("logged")
+    #expect(Log._swiftLoggerCount == 1)
+  }
+
   /// Confirms `isEnabled(for:)` evaluates both global and logger limits.
   @Test
   func isEnabledRespectsExposureLimits() {


### PR DESCRIPTION
## Summary
- expose new `debug`, `notice`, and `warning` helper methods on `Log`
- add shared `Log.debug`, `Log.notice`, and `Log.warning` wrappers
- cover new helpers in tests and documentation

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689a87a45da4833391667165d030f6a9