### PR TITLE
Refactor logging helpers for exposure and style routing

### DIFF
--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -109,16 +109,26 @@ struct WrkstrmLogTests {
 
   /// Validates the warning helper respects exposure limits.
   @Test
-  func warningHelperRespectsExposure() {
-    Log._reset()
-    Log.globalExposureLevel = .error
-    let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
-    log.warning("suppressed")
-    #expect(Log._swiftLoggerCount == 0)
-    Log.globalExposureLevel = .warning
-    log.warning("logged")
-    #expect(Log._swiftLoggerCount == 1)
-  }
+    func warningHelperRespectsExposure() {
+      Log._reset()
+      Log.globalExposureLevel = .error
+      let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
+      log.warning("suppressed")
+      #expect(Log._swiftLoggerCount == 0)
+      Log.globalExposureLevel = .warning
+      log.warning("logged")
+      #expect(Log._swiftLoggerCount == 1)
+    }
+
+    /// Verifies `effectiveLevel(for:)` filters based on exposure settings.
+    @Test
+    func effectiveLevelRespectsExposure() {
+      Log._reset()
+      Log.globalExposureLevel = .warning
+      let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
+      #expect(log.effectiveLevel(for: .info) == nil)
+      #expect(log.effectiveLevel(for: .error) == .error)
+    }
 
   /// Confirms `isEnabled(for:)` evaluates both global and logger limits.
   @Test


### PR DESCRIPTION
## Summary
- extract exposure-level evaluation into reusable `effectiveLevel(for:)`
- move style-specific output logic into dedicated helpers
- add tests for `effectiveLevel(for:)` and drop unnecessary SwiftLint suppression

## Testing
- `swift test`
- `curl -L -o /tmp/swiftlint.zip https://github.com/realm/SwiftLint/releases/latest/download/portable_swiftlint.zip`
- `/tmp/swiftlint_bin/swiftlint lint --path /workspace/WrkstrmLog` *(failed: cannot execute binary file)*

------
https://chatgpt.com/codex/tasks/task_e_689a8dd41328833393f30ed1ea0a6fd4