### PR TITLE
Introduce LoggerCache for centralized logger management

### DIFF
--- a/Sources/WrkstrmLog/Log+Cache.swift
+++ b/Sources/WrkstrmLog/Log+Cache.swift
@@ -1,0 +1,39 @@
+import Logging
+
+extension Log {
+  /// Global log exposure level applied across all loggers.
+  /// Clamped by each logger's `maxExposureLevel`.
+  public static var globalExposureLevel: Logging.Logger.Level {
+    get { Cache.shared.globalExposureLevel }
+    set { Cache.shared.globalExposureLevel = newValue }
+  }
+
+  #if DEBUG
+    /// Overrides the minimum logging level for the specified logger.
+    /// Available only in debug builds.
+    /// - Parameters:
+    ///   - logger: The logger to override.
+    ///   - level: The new minimum level to expose.
+    public static func overrideLevel(
+      for logger: Log,
+      to level: Logging.Logger.Level
+    ) {
+      Cache.shared.overrideLevel(for: logger, to: level)
+    }
+  #endif
+
+  // MARK: - Internal helpers for tests
+  static func reset() {
+    Cache.shared.reset()
+  }
+
+  static var swiftLoggerCount: Int {
+    Cache.shared.swiftLoggerCount
+  }
+
+  #if canImport(os)
+    static var osLoggerCount: Int {
+      Cache.shared.osLoggerCount
+    }
+  #endif
+}

--- a/Sources/WrkstrmLog/Log+CacheStorage.swift
+++ b/Sources/WrkstrmLog/Log+CacheStorage.swift
@@ -1,0 +1,135 @@
+import Dispatch
+import Logging
+
+#if canImport(os)
+  import os
+#endif
+
+extension Log {
+  /// Thread-safe cache storing logger instances and global exposure configuration.
+  ///
+  /// This type is an internal implementation detail used to coordinate logging
+  /// across the library. Access is synchronized via an internal serial dispatch
+  /// queue to ensure thread safety.
+  final class Cache: @unchecked Sendable {
+    /// Shared cache used across the library.
+    static let shared = Cache()
+
+    private let queue = DispatchQueue(label: "wrkstrm.log.logger")
+
+    private var swiftLoggers: [Log: Logging.Logger] = [:]
+    #if canImport(os)
+      private var osLoggers: [Log: OSLog] = [:]
+    #endif
+    #if DEBUG
+      private var overrideLevelMasks: [Log: Log.LevelMask] = [:]
+    #endif
+
+    #if DEBUG
+      private var exposureLevel: Logging.Logger.Level = .trace
+    #else
+      private var exposureLevel: Logging.Logger.Level = .critical
+    #endif
+
+    /// Returns the cached Swift logger for the provided `Log` instance, creating
+    /// one if necessary and updating its log level to `effectiveLevel`.
+    func logger(for log: Log, effectiveLevel: Logging.Logger.Level) -> Logging.Logger {
+      queue.sync {
+        if var existing = swiftLoggers[log] {
+          existing.logLevel = effectiveLevel
+          swiftLoggers[log] = existing
+          return existing
+        }
+        var newLogger = Logging.Logger(label: log.system)
+        newLogger.logLevel = effectiveLevel
+        swiftLoggers[log] = newLogger
+        return newLogger
+      }
+    }
+
+    #if canImport(os)
+      /// Returns the cached `OSLog` instance for the provided `Log`, creating one
+      /// if necessary.
+      func osLogger(for log: Log) -> OSLog {
+        queue.sync {
+          if let existing = osLoggers[log] {
+            return existing
+          }
+          let created = OSLog(subsystem: log.system, category: log.category)
+          osLoggers[log] = created
+          return created
+        }
+      }
+    #endif
+
+    /// Removes all cached loggers and resets the global exposure level. Intended
+    /// primarily for tests.
+    func reset() {
+      queue.sync {
+        swiftLoggers.removeAll()
+        #if canImport(os)
+          osLoggers.removeAll()
+        #endif
+        #if DEBUG
+          overrideLevelMasks.removeAll()
+        #endif
+        exposureLevel = .critical
+      }
+    }
+
+    /// Current number of cached SwiftLog loggers. Used in tests.
+    var swiftLoggerCount: Int { queue.sync { swiftLoggers.count } }
+
+    /// Returns whether a Swift logger exists for the given `Log`.
+    func hasSwiftLogger(for log: Log) -> Bool {
+      queue.sync { swiftLoggers[log] != nil }
+    }
+
+    #if canImport(os)
+      /// Current number of cached OSLog loggers. Used in tests.
+      var osLoggerCount: Int { queue.sync { osLoggers.count } }
+
+      /// Returns whether an OS logger exists for the given `Log`.
+      func hasOSLogger(for log: Log) -> Bool {
+        queue.sync { osLoggers[log] != nil }
+      }
+    #endif
+
+    /// Global log exposure level applied across all loggers. Clamped by each
+    /// logger's `maxExposureLevel`.
+    var globalExposureLevel: Logging.Logger.Level {
+      get { queue.sync { exposureLevel } }
+      set { queue.sync { exposureLevel = newValue } }
+    }
+
+    /// Overrides the minimum logging level for the specified logger. Available
+    /// only in debug builds.
+    /// - Parameters:
+    ///   - logger: The logger to override.
+    ///   - level: The new minimum level to expose.
+    func overrideLevel(
+      for logger: Log,
+      to level: Logging.Logger.Level
+    ) {
+      #if DEBUG
+        queue.sync { overrideLevelMasks[logger] = Log.LevelMask.threshold(level) }
+      #endif
+    }
+
+    #if DEBUG
+      /// Returns the override mask for the specified logger, if any.
+      func overrideMask(for logger: Log) -> Log.LevelMask? {
+        queue.sync { overrideLevelMasks[logger] }
+      }
+
+      /// Removes and returns the override mask for the specified logger.
+      func removeOverride(for logger: Log) -> Log.LevelMask? {
+        queue.sync { overrideLevelMasks.removeValue(forKey: logger) }
+      }
+    #endif
+
+    // MARK: - Private
+
+    private init() {}
+  }
+}

--- a/Sources/WrkstrmLog/Log+Levels.swift
+++ b/Sources/WrkstrmLog/Log+Levels.swift
@@ -61,44 +61,5 @@ extension Log {
         return .critical
       }
     }
-
-    /// Override level masks used during debugging.
-    /// Access is synchronized using `loggerQueue`.
-    nonisolated(unsafe) static var overrideLevelMasks: [Log: LevelMask] = [:]
   #endif
-
-  /// Global minimum log level applied to all loggers to limit message exposure.
-  /// Defaults to `.critical` and must be configured explicitly to expose additional levels.
-  #if DEBUG
-    nonisolated(unsafe) static var exposureLevel: Logging.Logger.Level = .trace
-  #else
-    nonisolated(unsafe) static var exposureLevel: Logging.Logger.Level = .critical
-  #endif
-
-  /// Overrides the minimum logging level for a specific logger. Only
-  /// available in debug builds.
-  /// - Parameters:
-  ///   - logger: The logger to override.
-  ///   - level: The new minimum logging level.
-  public static func overrideLevel(
-    for logger: Log,
-    to level: Logging.Logger.Level
-  ) {
-    #if DEBUG
-      loggerQueue.sync {
-        overrideLevelMasks[logger] = LevelMask.threshold(level)
-      }
-    #endif
-  }
-
-  /// Global log exposure level applied across all loggers.
-  ///
-  /// The value is clamped by each logger's `maxExposureLevel`, ensuring
-  /// libraries must explicitly opt in before more verbose logging is emitted.
-  /// Invoke during application initialization to expose additional logs beyond
-  /// the default `.critical` level.
-  public static var globalExposureLevel: Logging.Logger.Level {
-    get { loggerQueue.sync { exposureLevel } }
-    set { loggerQueue.sync { exposureLevel = newValue } }
-  }
 }

--- a/Sources/WrkstrmLog/Log+Shared.swift
+++ b/Sources/WrkstrmLog/Log+Shared.swift
@@ -13,9 +13,8 @@ extension Log {
   {
     didSet {
       #if DEBUG
-        let override = overrideLevelMasks.removeValue(forKey: oldValue)
-        if let mask = override {
-          overrideLevelMasks[shared] = mask
+        if let mask = Cache.shared.removeOverride(for: oldValue) {
+          Cache.shared.overrideLevel(for: shared, to: mask.minimumLevel)
         }
       #endif
       shared.verbose("New Logger: \(shared)")

--- a/Tests/WrkstrmLogTests/OSLoggerTests.swift
+++ b/Tests/WrkstrmLogTests/OSLoggerTests.swift
@@ -9,27 +9,27 @@ import Testing
     /// Confirms that an `OSLogger` instance is reused across mutations.
     @Test
     func osLoggerReuse() {
-      Log._reset()
+      Log.reset()
       Log.globalExposureLevel = .trace
       let log = Log(style: .os, maxExposureLevel: .trace, options: [.prod])
-      #expect(Log._osLoggerCount == 0)
+      #expect(Log.osLoggerCount == 0)
       log.info("first")
-      #expect(Log._osLoggerCount == 1)
+      #expect(Log.osLoggerCount == 1)
 
       var mutated = log
       mutated.maxFunctionLength = 10
       mutated.info("second")
-      #expect(Log._osLoggerCount == 1)
+      #expect(Log.osLoggerCount == 1)
     }
 
     /// Ensures `.prod` loggers still record messages at allowed levels.
     @Test
     func logLevelWorksInProd() {
-      Log._reset()
+      Log.reset()
       Log.globalExposureLevel = .trace
       let log = Log(style: .os, maxExposureLevel: .trace, options: [.prod])
       log.info("not ignored")
-      #expect(Log._osLoggerCount == 1)
+      #expect(Log.osLoggerCount == 1)
     }
   }
 #endif

--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -7,16 +7,16 @@ struct WrkstrmLogTests {
   /// Verifies that a single Swift logger instance is reused after mutation.
   @Test
   func swiftLoggerReuse() {
-    Log._reset()
+    Log.reset()
     Log.globalExposureLevel = .trace
     let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     log.info("first")
-    #expect(Log._swiftLoggerCount == 1)
+    #expect(Log.swiftLoggerCount == 1)
 
     var mutated = log
     mutated.maxFunctionLength = 10
     mutated.info("second")
-    #expect(Log._swiftLoggerCount == 1)
+    #expect(Log.swiftLoggerCount == 1)
   }
 
   /// Confirms hashing ignores mutable properties that do not affect identity.
@@ -49,91 +49,91 @@ struct WrkstrmLogTests {
   /// Guarantees disabled loggers do not create underlying logger instances.
   @Test
   func disabledProducesNoLoggers() {
-    Log._reset()
+    Log.reset()
     Log.globalExposureLevel = .trace
     Log.disabled.info("silence")
-    #expect(Log._swiftLoggerCount == 0)
+    #expect(Log.swiftLoggerCount == 0)
   }
 
   /// Checks that increasing global exposure filters messages below the threshold.
   @Test
   func exposureLimitFiltersMessages() {
-    Log._reset()
+    Log.reset()
     Log.globalExposureLevel = .warning
     let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     log.info("suppressed")
-    #expect(Log._swiftLoggerCount == 0)
+    #expect(Log.swiftLoggerCount == 0)
     Log.globalExposureLevel = .trace
     log.info("logged")
-    #expect(Log._swiftLoggerCount == 1)
+    #expect(Log.swiftLoggerCount == 1)
   }
 
   /// Verifies a logger's max exposure level is respected even when global limits differ.
   @Test
   func loggerMaxExposureLevelRespected() {
-    Log._reset()
+    Log.reset()
     Log.globalExposureLevel = .trace
     let log = Log(style: .swift, maxExposureLevel: .error, options: [.prod])
     #expect(log.maxExposureLevel == .error)
     log.info("suppressed")
-    #expect(Log._swiftLoggerCount == 0)
+    #expect(Log.swiftLoggerCount == 0)
     log.error("logged")
-    #expect(Log._swiftLoggerCount == 1)
+    #expect(Log.swiftLoggerCount == 1)
   }
 
   /// Validates the debug helper respects exposure limits.
   @Test
   func debugHelperRespectsExposure() {
-    Log._reset()
+    Log.reset()
     Log.globalExposureLevel = .info
     let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     log.debug("suppressed")
-    #expect(Log._swiftLoggerCount == 0)
+    #expect(Log.swiftLoggerCount == 0)
     Log.globalExposureLevel = .debug
     log.debug("logged")
-    #expect(Log._swiftLoggerCount == 1)
+    #expect(Log.swiftLoggerCount == 1)
   }
 
   /// Validates the notice helper respects exposure limits.
   @Test
   func noticeHelperRespectsExposure() {
-    Log._reset()
+    Log.reset()
     Log.globalExposureLevel = .warning
     let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     log.notice("suppressed")
-    #expect(Log._swiftLoggerCount == 0)
+    #expect(Log.swiftLoggerCount == 0)
     Log.globalExposureLevel = .notice
     log.notice("logged")
-    #expect(Log._swiftLoggerCount == 1)
+    #expect(Log.swiftLoggerCount == 1)
   }
 
   /// Validates the warning helper respects exposure limits.
   @Test
-    func warningHelperRespectsExposure() {
-      Log._reset()
-      Log.globalExposureLevel = .error
-      let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
-      log.warning("suppressed")
-      #expect(Log._swiftLoggerCount == 0)
-      Log.globalExposureLevel = .warning
-      log.warning("logged")
-      #expect(Log._swiftLoggerCount == 1)
-    }
+  func warningHelperRespectsExposure() {
+    Log.reset()
+    Log.globalExposureLevel = .error
+    let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
+    log.warning("suppressed")
+    #expect(Log.swiftLoggerCount == 0)
+    Log.globalExposureLevel = .warning
+    log.warning("logged")
+    #expect(Log.swiftLoggerCount == 1)
+  }
 
-    /// Verifies `effectiveLevel(for:)` filters based on exposure settings.
-    @Test
-    func effectiveLevelRespectsExposure() {
-      Log._reset()
-      Log.globalExposureLevel = .warning
-      let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
-      #expect(log.effectiveLevel(for: .info) == nil)
-      #expect(log.effectiveLevel(for: .error) == .error)
-    }
+  /// Verifies `effectiveLevel(for:)` filters based on exposure settings.
+  @Test
+  func effectiveLevelRespectsExposure() {
+    Log.reset()
+    Log.globalExposureLevel = .warning
+    let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
+    #expect(log.effectiveLevel(for: .info) == nil)
+    #expect(log.effectiveLevel(for: .error) == .error)
+  }
 
   /// Confirms `isEnabled(for:)` evaluates both global and logger limits.
   @Test
   func isEnabledRespectsExposureLimits() {
-    Log._reset()
+    Log.reset()
     Log.globalExposureLevel = .warning
     let log = Log(style: .swift, maxExposureLevel: .info, options: [.prod])
     #expect(log.isEnabled(for: .info) == false)
@@ -143,7 +143,7 @@ struct WrkstrmLogTests {
   /// Validates `ifEnabled(for:_:)` executes the closure only when enabled.
   @Test
   func ifEnabledExecutesConditionally() {
-    Log._reset()
+    Log.reset()
     Log.globalExposureLevel = .warning
     let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     var executed = false
@@ -156,28 +156,28 @@ struct WrkstrmLogTests {
   /// Ensures raising the global exposure level does not override a logger's limit.
   @Test
   func globalExposureIncreaseDoesNotOverrideLoggerMax() {
-    Log._reset()
+    Log.reset()
     let log = Log(style: .swift, options: [.prod])
     log.error("suppressed")
-    #expect(Log._swiftLoggerCount == 0)
+    #expect(Log.swiftLoggerCount == 0)
     Log.globalExposureLevel = .trace
     #expect(log.maxExposureLevel == .critical)
     log.error("still suppressed")
-    #expect(Log._swiftLoggerCount == 0)
+    #expect(Log.swiftLoggerCount == 0)
   }
 
   #if DEBUG
     /// Validates that overriding the level adjusts logging in debug builds.
     @Test
     func overrideLevelAdjustsLoggingInDebug() {
-      Log._reset()
+      Log.reset()
       Log.globalExposureLevel = .trace
       let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
       log.info("suppressed")
-      #expect(Log._swiftLoggerCount == 1)
+      #expect(Log.swiftLoggerCount == 1)
       Log.overrideLevel(for: log, to: .debug)
       log.info("logged")
-      #expect(Log._swiftLoggerCount == 1)
+      #expect(Log.swiftLoggerCount == 1)
     }
   #endif
 
@@ -192,23 +192,23 @@ struct WrkstrmLogTests {
     /// Verifies the default logger is disabled in release builds.
     @Test
     func defaultLoggerDisabledInRelease() {
-      Log._reset()
+      Log.reset()
       Log.globalExposureLevel = .trace
       let log = Log()
       log.info("silence")
       #expect(log.style == .disabled)
-      #expect(Log._swiftLoggerCount == 0)
+      #expect(Log.swiftLoggerCount == 0)
     }
 
     /// Ensures a logger with the `.prod` option remains enabled in release builds.
     @Test
     func loggerWithProdOptionEnabledInRelease() {
-      Log._reset()
+      Log.reset()
       Log.globalExposureLevel = .trace
       let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
       log.info("hello")
       #expect(log.style == .swift)
-      #expect(Log._swiftLoggerCount == 1)
+      #expect(Log.swiftLoggerCount == 1)
     }
   #endif
 }


### PR DESCRIPTION
## Summary
- move logger cache into `Log.Cache` to encapsulate logger storage and exposure state
- update logging APIs to reference `Cache.shared`

## Testing
- `swift format -i -r -p Sources Tests`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689a9515f3d483339d4fcba897000ae7