### PR TITLE
cache path info for logs

### DIFF
--- a/Sources/WrkstrmLog/Log+Cache.swift
+++ b/Sources/WrkstrmLog/Log+Cache.swift
@@ -25,10 +25,15 @@ extension Log {
   // MARK: - Internal helpers for tests
   static func reset() {
     Cache.shared.reset()
+    Inject.usePathInfoCache(true)
   }
 
   static var swiftLoggerCount: Int {
     Cache.shared.swiftLoggerCount
+  }
+
+  static var pathInfoCount: Int {
+    Cache.shared.pathInfoCount
   }
 
   #if canImport(os)

--- a/Sources/WrkstrmLog/Log+Inject.swift
+++ b/Sources/WrkstrmLog/Log+Inject.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+extension Log {
+  /// Runtime injection points for choosing alternate implementations.
+  public enum Inject {
+    // Current path info provider. Defaults to using the shared cache.
+    internal nonisolated(unsafe) static var pathInfoProvider: @Sendable (String) -> Cache.PathInfo =
+      {
+        Cache.shared.pathInfo(for: $0)
+      }
+
+    /// Returns path information for a given file using the configured provider.
+    internal static func pathInfo(for file: String) -> Cache.PathInfo {
+      pathInfoProvider(file)
+    }
+
+    /// Configures whether file path information should be cached or computed each call.
+    /// - Parameter useCache: When `true`, path info results are cached and reused. When `false`,
+    ///   path info is recalculated every time without updating the cache.
+    public static func usePathInfoCache(_ useCache: Bool) {
+      if useCache {
+        pathInfoProvider = { Cache.shared.pathInfo(for: $0) }
+      } else {
+        pathInfoProvider = { file in
+          let url = URL(fileURLWithPath: file)
+          let lastComponent = url.lastPathComponent
+          let trimmed = lastComponent.replacingOccurrences(of: ".swift", with: "")
+          return Cache.PathInfo(url: url, fileName: trimmed, lastPathComponent: lastComponent)
+        }
+      }
+    }
+  }
+}

--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -364,17 +364,13 @@ public struct Log: Hashable, @unchecked Sendable {
     dso: UnsafeRawPointer
   ) {
     guard let effectiveLevel = effectiveLevel(for: level) else { return }
-    let url = URL(fileURLWithPath: file)
-    let fileName = url.lastPathComponent.replacingOccurrences(
-      of: ".swift",
-      with: ""
-    )
+    let pathInfo = Inject.pathInfo(for: file)
     let functionString = formattedFunction(function)
     switch style {
     case .print:
       logPrint(
         level,
-        fileName: fileName,
+        fileName: pathInfo.fileName,
         function: functionString,
         line: line,
         describable: describable
@@ -384,7 +380,7 @@ public struct Log: Hashable, @unchecked Sendable {
         logOS(
           level,
           describable: describable,
-          url: url,
+          pathInfo: pathInfo,
           function: functionString,
           line: line,
           dso: dso
@@ -395,7 +391,7 @@ public struct Log: Hashable, @unchecked Sendable {
         level,
         effectiveLevel: effectiveLevel,
         describable: describable,
-        url: url,
+        pathInfo: pathInfo,
         function: functionString,
         file: file,
         line: line
@@ -460,7 +456,7 @@ public struct Log: Hashable, @unchecked Sendable {
     private func logOS(
       _ level: Logging.Logger.Level,
       describable: Any,
-      url: URL,
+      pathInfo: Cache.PathInfo,
       function: String,
       line: UInt,
       dso: UnsafeRawPointer
@@ -471,7 +467,7 @@ public struct Log: Hashable, @unchecked Sendable {
         dso: dso,
         log: logger,
         "%s-%i|%s| %s",
-        url.lastPathComponent,
+        pathInfo.lastPathComponent,
         line,
         function,
         String(describing: describable)
@@ -483,7 +479,7 @@ public struct Log: Hashable, @unchecked Sendable {
     _ level: Logging.Logger.Level,
     effectiveLevel: Logging.Logger.Level,
     describable: Any,
-    url: URL,
+    pathInfo: Cache.PathInfo,
     function: String,
     file: String,
     line: UInt
@@ -492,7 +488,7 @@ public struct Log: Hashable, @unchecked Sendable {
     logger.log(
       level: level,
       "\(line)|\(function)| \(String(describing: describable))",
-      source: url.lastPathComponent,
+      source: pathInfo.lastPathComponent,
       file: file,
       function: function,
       line: line

--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -55,6 +55,33 @@ struct WrkstrmLogTests {
     #expect(Log.swiftLoggerCount == 0)
   }
 
+  /// Ensures path information is cached and reused across log calls.
+  @Test
+  func pathInfoCaching() {
+    Log.reset()
+    Log.globalExposureLevel = .trace
+    let logger = Log(style: .print, maxExposureLevel: .trace, options: [.prod])
+    #expect(Log.pathInfoCount == 0)
+    logger.info("first")
+    #expect(Log.pathInfoCount == 1)
+    logger.info("second")
+    #expect(Log.pathInfoCount == 1)
+  }
+
+  /// Allows disabling path information caching at runtime.
+  @Test
+  func pathInfoCachingCanBeDisabled() {
+    Log.reset()
+    Log.Inject.usePathInfoCache(false)
+    Log.globalExposureLevel = .trace
+    let logger = Log(style: .print, maxExposureLevel: .trace, options: [.prod])
+    #expect(Log.pathInfoCount == 0)
+    logger.info("first")
+    #expect(Log.pathInfoCount == 0)
+    logger.info("second")
+    #expect(Log.pathInfoCount == 0)
+  }
+
   /// Checks that increasing global exposure filters messages below the threshold.
   @Test
   func exposureLimitFiltersMessages() {


### PR DESCRIPTION
## Summary
- cache URL and file-name data per source path
- allow runtime injection of cached or uncached path info
- test path info caching and its configurability

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689aa1baddcc833384a12ee82a8fcf67