### PR TITLE
docs: document log levels and link reference

### DIFF
--- a/Documentation/LoggingAPIs.docc/Articles/LogLevels.md
+++ b/Documentation/LoggingAPIs.docc/Articles/LogLevels.md
@@ -1,0 +1,50 @@
+# Log Levels
+
+Understand the purpose of each log level in WrkstrmLog.
+
+WrkstrmLog provides seven levels with increasing severity. `verbose`
+messages are emitted at the `debug` level.
+
+## Trace
+Use trace for the most detailed events, like entering and exiting functions
+or iterating over loops.
+```swift
+logger.trace("starting request")
+```
+
+## Debug
+Diagnostic information that helps during development. `verbose` is an alias
+for this level.
+```swift
+logger.debug("parsed response: \(response)")
+```
+
+## Info
+General operational messages that track the progress of your app.
+```swift
+logger.info("request completed")
+```
+
+## Notice
+Important events that aren't problems but are worth noting.
+```swift
+logger.notice("user signed in")
+```
+
+## Warning
+Potential issues that might require attention.
+```swift
+logger.warning("retrying after timeout")
+```
+
+## Error
+A recoverable failure within the application.
+```swift
+logger.error("failed to save item: \(error)")
+```
+
+## Critical
+Severe problems that usually terminate execution or cause data loss.
+```swift
+Log.guard("database unavailable")
+```

--- a/Documentation/LoggingAPIs.docc/Tutorials/LoggingAPIs.tutorial
+++ b/Documentation/LoggingAPIs.docc/Tutorials/LoggingAPIs.tutorial
@@ -52,4 +52,9 @@
     ```
     }
   }
+
+  @Section(title: "Understand Log Levels") {
+    For a deeper explanation of each level and example messages, see
+    <doc:LogLevels>.
+  }
 }

--- a/README.md
+++ b/README.md
@@ -84,7 +84,35 @@ targets: [
    | error    | ❗ |
    | critical | 🚨 |
 
-4. **Disable or enable logging in production** 🔇
+   Each log level represents a different severity and use case. `verbose`
+   messages map to the `debug` level and are emitted at the same severity.
+
+   **trace** captures extremely fine-grained details such as function
+   entry, exit, or loop iterations—useful for deep troubleshooting during
+   development but rarely enabled in production.
+
+   **debug** records diagnostic information like configuration values or
+   request payloads. Enable it when investigating issues or verifying
+   behavior.
+
+   **info** notes general events in the application lifecycle, such as
+   successful network calls or completed tasks. These messages are useful
+   for understanding normal operation.
+
+   **notice** highlights notable events that aren't errors or warnings,
+   like a user signing in or a cache refresh. They call attention without
+   implying a problem.
+
+   **warning** flags potential issues that might require attention, such
+   as retrying a request or using a deprecated API.
+
+   **error** indicates a failure in an operation that the app can often
+   recover from, for example a failed save that triggers a retry.
+
+   **critical** signals serious problems that usually halt execution or
+   result in data loss and should be addressed immediately.
+
+ 4. **Disable or enable logging in production** 🔇
 
    Loggers default to `.disabled` in release builds. Use the `.prod` option to keep them active or the `.disabled` style for a silent logger.
 


### PR DESCRIPTION
## Summary
- explain each log level in README and note that `verbose` is treated as `debug`
- add `LogLevels` DocC article with examples for every level
- link the new article from the Logging APIs tutorial

## Testing
- `swiftlint`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689ad94910708333960c9b8ff44c90a4