### PR TITLE
test: verify OSLog reuse and suppression

### DIFF
--- a/Tests/WrkstrmLogTests/OSLoggerTests.swift
+++ b/Tests/WrkstrmLogTests/OSLoggerTests.swift
@@ -31,5 +31,34 @@ import Testing
       log.info("not ignored")
       #expect(Log.osLoggerCount == 1)
     }
+
+    /// Verifies `OSLog` reuse across subsystem/category pairs and suppression when
+    /// global exposure is low.
+    @Test
+    func osLogReuseAcrossSubsystemsAndSuppressedLevels() {
+      Log.reset()
+      Log.globalExposureLevel = .trace
+      let first = Log(
+        system: "one", category: "first", style: .os, maxExposureLevel: .trace, options: [.prod])
+      first.info("initial")
+      #expect(Log.osLoggerCount == 1)
+
+      let second = Log(
+        system: "two", category: "second", style: .os, maxExposureLevel: .trace, options: [.prod])
+      second.info("next")
+      #expect(Log.osLoggerCount == 2)
+
+      let firstDuplicate = Log(
+        system: "one", category: "first", style: .os, maxExposureLevel: .trace, options: [.prod])
+      firstDuplicate.info("again")
+      #expect(Log.osLoggerCount == 2)
+
+      Log.globalExposureLevel = .error
+      let suppressed = Log(
+        system: "three", category: "third", style: .os, maxExposureLevel: .trace, options: [.prod])
+      suppressed.debug("ignored")
+      #expect(Log.osLoggerCount == 2)
+      #expect(!Log.Cache.shared.hasOSLogger(for: suppressed))
+    }
   }
 #endif


### PR DESCRIPTION
## Summary
- add test covering OSLog reuse across subsystem/category pairs
- ensure unsupported levels are skipped when global exposure is low

## Testing
- `swift format -i -r -p .`
- `swiftlint` *(fails: command not found)*
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_689adff05fdc833385a392d90e16bb15