### PR TITLE
Add cache concurrency test

### DIFF
--- a/Tests/WrkstrmLogTests/CacheConcurrencyTests.swift
+++ b/Tests/WrkstrmLogTests/CacheConcurrencyTests.swift
@@ -1,0 +1,31 @@
+import Dispatch
+import Testing
+
+@testable import WrkstrmLog
+
+extension WrkstrmLogTests {
+  /// Ensures the cache produces consistent results when accessed from many concurrent tasks.
+  @Test
+  func cacheConcurrency() {
+    Log.reset()
+    Log.globalExposureLevel = .trace
+    #expect(Log.swiftLoggerCount == 0)
+    #expect(Log.pathInfoCount == 0)
+
+    let logger = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
+    let group = DispatchGroup()
+    let queue = DispatchQueue(label: "cache-concurrency", attributes: .concurrent)
+
+    for _ in 0..<100 {
+      group.enter()
+      queue.async {
+        logger.info("entry")
+        group.leave()
+      }
+    }
+    group.wait()
+
+    #expect(Log.swiftLoggerCount == 1)
+    #expect(Log.pathInfoCount == 1)
+  }
+}


### PR DESCRIPTION
## Summary
- test cache uses one logger and path info under concurrent logging

## Testing
- `swift test`
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689adff591808333bd07dc6f5a4dfc03