### PR TITLE
Organize tests with MARK sections

### DIFF
--- a/Tests/WrkstrmLogTests/CacheConcurrencyTests.swift
+++ b/Tests/WrkstrmLogTests/CacheConcurrencyTests.swift
@@ -3,6 +3,8 @@ import Testing
 
 @testable import WrkstrmLog
 
+// MARK: - Cache Concurrency
+
 extension WrkstrmLogTests {
   /// Ensures the cache produces consistent results when accessed from many concurrent tasks.
   @Test

--- a/Tests/WrkstrmLogTests/LevelExtensionsTests.swift
+++ b/Tests/WrkstrmLogTests/LevelExtensionsTests.swift
@@ -7,6 +7,8 @@ import Testing
   import os
 #endif
 
+// MARK: - Level Extensions
+
 @Suite("Logging.Level extensions", .serialized)
 struct LevelExtensionsTests {
   /// Ensures each logging level maps to the expected emoji.

--- a/Tests/WrkstrmLogTests/LevelMaskTests.swift
+++ b/Tests/WrkstrmLogTests/LevelMaskTests.swift
@@ -3,6 +3,8 @@ import Testing
 
 @testable import WrkstrmLog
 
+// MARK: - Level Masks
+
 #if DEBUG
   @Suite("Log.LevelMask", .serialized)
   struct LevelMaskTests {

--- a/Tests/WrkstrmLogTests/OSLoggerTests.swift
+++ b/Tests/WrkstrmLogTests/OSLoggerTests.swift
@@ -4,6 +4,8 @@ import Testing
   import os
   @testable import WrkstrmLog
 
+  // MARK: - OS Logger
+
   @Suite("OSLogger", .serialized)
   struct OSLoggerTests {
     /// Confirms that an `OSLogger` instance is reused across mutations.

--- a/Tests/WrkstrmLogTests/ProcessInfoXcodeTests.swift
+++ b/Tests/WrkstrmLogTests/ProcessInfoXcodeTests.swift
@@ -9,6 +9,8 @@ import Testing
   import Glibc
 #endif
 
+// MARK: - Xcode Environment Detection
+
 @Suite("ProcessInfo Xcode detection", .serialized)
 struct ProcessInfoXcodeTests {
   /// Temporarily sets an environment variable, returning a closure to restore it.

--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -31,6 +31,8 @@ func expectFatalError(executing: @escaping () -> Void) -> (String, Int32) {
   }
 }
 
+// MARK: - Core Logging Behavior
+
 @Suite("WrkstrmLog", .serialized)
 struct WrkstrmLogTests {
   /// Verifies that a single Swift logger instance is reused after mutation.


### PR DESCRIPTION
## Summary
- group test suites using `// MARK:` for easier navigation

## Testing
- `swift test`
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae4334b1c8333b886bad4dd8a2e33