### PR TITLE
Replace fork-based fatal error test for macOS

### DIFF
--- a/Sources/WrkstrmLog/FatalErrorUtil.swift
+++ b/Sources/WrkstrmLog/FatalErrorUtil.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+final class FatalErrorStorage: @unchecked Sendable {
+  var handler: (String, StaticString, UInt) -> Never
+
+  init() {
+    handler = { message, file, line in
+      Swift.fatalError(message, file: file, line: line)
+    }
+  }
+}
+
+let fatalErrorStorage = FatalErrorStorage()
+
+func fatalErrorHandler(
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #fileID,
+  line: UInt = #line
+) -> Never {
+  fatalErrorStorage.handler(message(), file, line)
+}

--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -341,7 +341,7 @@ public struct Log: Hashable, @unchecked Sendable {
     column: UInt = #column,
     dso: UnsafeRawPointer = #dsohandle,
   ) -> Never {
-    guard style != .disabled else { fatalError() }
+    guard style != .disabled else { fatalErrorHandler() }
     log(
       .critical,
       describable: describable ?? "",
@@ -351,7 +351,7 @@ public struct Log: Hashable, @unchecked Sendable {
       column: column,
       dso: dso,
     )
-    fatalError("Guard failed: \(String(describing: describable))")
+    fatalErrorHandler("Guard failed: \(String(describing: describable))")
   }
 
   private func log(


### PR DESCRIPTION
## Summary
- add overridable fatal error handler to allow testing without `fork`
- rewrite `expectFatalError` to run closure on a separate `Thread`
- update guard logic to use the new handler

## Testing
- `swift format -i -r -p Sources/WrkstrmLog/FatalErrorUtil.swift Sources/WrkstrmLog/Log.swift Tests/WrkstrmLogTests/WrkstrmLogTests.swift`
- `swiftlint` *(fails: command not found)*
- `apt-get install -y swiftlint` *(fails: Unable to locate package swiftlint)*
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689ae7bdb6708333a89d1bf422f650c0