### PR TITLE
Document release naming convention

### DIFF
--- a/AGENCY.md
+++ b/AGENCY.md
@@ -1,0 +1,4 @@
+# WrkstrmLog Release Naming
+Releases adopt tree species codenames in alphabetical order to mirror logging.
+The series began with v2.1.0 "Aspen" and will continue with "Birch", "Cedar", etc.
+Include the codename alongside the semantic version in release pages and documentation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,8 @@ These instructions apply to all files in the WrkstrmLog repository unless a more
 - Run the full test suite with `swift test` and ensure it passes.
 - Write descriptive commit messages and keep pull requests focused.
 
+
+## Release Naming Convention
+WrkstrmLog releases are nicknamed after tree species in alphabetical order—a nod to logging.
+For example, v2.1.0 is "Aspen"; upcoming releases will continue with names like "Birch", "Cedar", etc.
+Use the codename in release notes, tags, and announcements.


### PR DESCRIPTION
## Summary
- note that releases use tree-species codenames in alphabetical order
- add AGENCY file describing the naming approach

## Testing
- `swift format -i -r -p Sources Tests` (no output)
- `swiftlint` *(fails: command not found)*
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_689c00fbced48333b6f0bf4e14b43e7f