### PR TITLE
Use shared swift-format configuration

### DIFF
--- a/.github/workflows/wrkstrm-log-swiftlint.yml
+++ b/.github/workflows/wrkstrm-log-swiftlint.yml
@@ -51,5 +51,10 @@ jobs:
         sudo mv swiftlint_tmp/swiftlint /usr/local/bin/
     - name: Download SwiftLint Configuration
       run: curl -O https://raw.githubusercontent.com/wrkstrm/configs/main/linting/.swiftlint.yml
+    - name: Download Swift Format Configuration
+      run: curl -O https://raw.githubusercontent.com/wrkstrm/configs/main/linting/.swift-format
+    - name: Swift Format
+      # This is the only Swift formatting step.
+      run: swift format --configuration .swift-format -i -r -p
     - name: SwiftLint
       run: swiftlint

--- a/AGENCY.md
+++ b/AGENCY.md
@@ -2,3 +2,6 @@
 Releases adopt tree species codenames in alphabetical order to mirror logging.
 The series began with v2.1.0 "Aspen" and will continue with "Birch", "Cedar", etc.
 Include the codename alongside the semantic version in release pages and documentation.
+
+## Formatting
+Swift code should be formatted with `swift format --configuration https://raw.githubusercontent.com/wrkstrm/configs/main/linting/.swift-format -i -r -p`. This is the only Swift formatting step to run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ WrkstrmLog is a Swift logging framework. Use these guidelines when contributing 
 These instructions apply to all files in the WrkstrmLog repository unless a more specific `AGENTS.md` file overrides them.
 
 ## Contribution Guidelines
-- Format any modified Swift files with `swift format -i -r -p`.
+- Format any modified Swift files with `swift format --configuration https://raw.githubusercontent.com/wrkstrm/configs/main/linting/.swift-format -i -r -p`. This is the only Swift formatting step to run.
 - Lint the project with `swiftlint` using the included configuration.
 - Run the full test suite with `swift test` and ensure it passes.
 - Write descriptive commit messages and keep pull requests focused.


### PR DESCRIPTION
## Summary
- download shared swift-format configuration in SwiftLint workflow
- document remote swift-format command as the only formatting step

## Testing
- `swiftlint 2>&1 | tail -n 20`
- `swift test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689edfbdca988333a4d4501c90f619b1