### PR TITLE
docs: fix grammar in info log comment

### DIFF
--- a/Sources/WrkstrmLog/Log+Shared.swift
+++ b/Sources/WrkstrmLog/Log+Shared.swift
@@ -75,7 +75,7 @@ extension Log {
     )
   }
 
-  /// Logs a info message with the specified parameters.
+  /// Logs an info message with the specified parameters.
   ///
   /// - Parameters:
   ///   - describable: The message string to log.


### PR DESCRIPTION
## Summary
- correct article in info log helper comment

## Testing
- `swift-format format --configuration /tmp/.swift-format-clean -i -r Sources/WrkstrmLog/Log+Shared.swift`
- `swiftlint lint Sources/WrkstrmLog/Log+Shared.swift`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689ee4a8a410833392750ae9a6b8ffad