### PR TITLE
Update Log.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ extension Package {
 
     public static let shared: Inject = ProcessInfo.useLocalDeps ? .local : .remote
 
-    static var local: Inject = .init(swiftSettings: [.localSwiftSettings])
+    static var local: Inject = .init(swiftSettings: [.local])
     static var remote: Inject = .init()
   }
 }
@@ -51,7 +51,7 @@ extension Package {
 // MARK: - PackageDescription extensions
 
 extension SwiftSetting {
-  public static let localSwiftSettings: SwiftSetting = .unsafeFlags([
+  public static let local: SwiftSetting = .unsafeFlags([
     "-Xfrontend",
     "-warn-long-expression-type-checking=10",
   ])

--- a/Sources/WrkstrmLog/Log+Cache.swift
+++ b/Sources/WrkstrmLog/Log+Cache.swift
@@ -28,8 +28,8 @@ extension Log {
     Inject.usePathInfoCache(true)
   }
 
-  static var swiftLoggerCount: Int {
-    Cache.shared.swiftLoggerCount
+  static var swiftCount: Int {
+    Cache.shared.swiftCount
   }
 
   static var pathInfoCount: Int {

--- a/Sources/WrkstrmLog/Log+Cache.swift
+++ b/Sources/WrkstrmLog/Log+Cache.swift
@@ -37,8 +37,8 @@ extension Log {
   }
 
   #if canImport(os)
-  static var osLoggerCount: Int {
-    Cache.shared.osLoggerCount
+  static var osCount: Int {
+    Cache.shared.osCount
   }
   #endif
 }

--- a/Sources/WrkstrmLog/Log+CacheStorage.swift
+++ b/Sources/WrkstrmLog/Log+CacheStorage.swift
@@ -117,7 +117,7 @@ extension Log {
 
     #if canImport(os)
     /// Current number of cached OSLog loggers. Used in tests.
-    var osLoggerCount: Int { queue.sync { osLoggers.count } }
+    var osCount: Int { queue.sync { osLoggers.count } }
 
     /// Returns whether an OS logger exists for the given `Log`.
     func hasOSLogger(for log: Log) -> Bool {

--- a/Sources/WrkstrmLog/Log+CacheStorage.swift
+++ b/Sources/WrkstrmLog/Log+CacheStorage.swift
@@ -106,7 +106,7 @@ extension Log {
     }
 
     /// Current number of cached SwiftLog loggers. Used in tests.
-    var swiftLoggerCount: Int { queue.sync { swiftLoggers.count } }
+    var swiftCount: Int { queue.sync { swiftLoggers.count } }
 
     var pathInfoCount: Int { queue.sync { pathInfos.count } }
 

--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -168,7 +168,7 @@ public struct Log: Hashable, @unchecked Sendable {
     // Verbose messages are lower priority than standard informational logs.
     // Map them to the debug log level so they can be filtered separately.
     log(
-      .debug,
+      .trace,
       describable: describable,
       file: file,
       function: function,

--- a/Sources/WrkstrmLog/Log.swift
+++ b/Sources/WrkstrmLog/Log.swift
@@ -166,7 +166,7 @@ public struct Log: Hashable, @unchecked Sendable {
   ) {
     guard style != .disabled else { return }
     // Verbose messages are lower priority than standard informational logs.
-    // Map them to the debug log level so they can be filtered separately.
+    // Map them to the trace log level so they can be filtered separately.
     log(
       .trace,
       describable: describable,

--- a/Tests/WrkstrmLogTests/CacheConcurrencyTests.swift
+++ b/Tests/WrkstrmLogTests/CacheConcurrencyTests.swift
@@ -11,7 +11,7 @@ extension WrkstrmLogTests {
   func cacheConcurrency() {
     Log.reset()
     Log.globalExposureLevel = .trace
-    #expect(Log.swiftLoggerCount == 0)
+    #expect(Log.swiftCount == 0)
     #expect(Log.pathInfoCount == 0)
 
     let logger = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
@@ -28,7 +28,7 @@ extension WrkstrmLogTests {
     group.wait()
     let waitResult = group.wait(timeout: .now() + 5)
     #expect(waitResult == .success, "DispatchGroup wait timed out")
-    #expect(Log.swiftLoggerCount == 1)
+    #expect(Log.swiftCount == 1)
     #expect(Log.pathInfoCount == 1)
   }
 }

--- a/Tests/WrkstrmLogTests/OSLoggerTests.swift
+++ b/Tests/WrkstrmLogTests/OSLoggerTests.swift
@@ -14,14 +14,14 @@ struct OSLoggerTests {
     Log.reset()
     Log.globalExposureLevel = .trace
     let log = Log(style: .os, maxExposureLevel: .trace, options: [.prod])
-    #expect(Log.osLoggerCount == 0)
+    #expect(Log.osCount == 0)
     log.info("first")
-    #expect(Log.osLoggerCount == 1)
+    #expect(Log.osCount == 1)
 
     var mutated = log
     mutated.maxFunctionLength = 10
     mutated.info("second")
-    #expect(Log.osLoggerCount == 1)
+    #expect(Log.osCount == 1)
   }
 
   /// Ensures `.prod` loggers still record messages at allowed levels.
@@ -31,7 +31,7 @@ struct OSLoggerTests {
     Log.globalExposureLevel = .trace
     let log = Log(style: .os, maxExposureLevel: .trace, options: [.prod])
     log.info("not ignored")
-    #expect(Log.osLoggerCount == 1)
+    #expect(Log.osCount == 1)
   }
 
   /// Verifies `OSLog` reuse across subsystem/category pairs and suppression when
@@ -43,23 +43,23 @@ struct OSLoggerTests {
     let first = Log(
       system: "one", category: "first", style: .os, maxExposureLevel: .trace, options: [.prod])
     first.info("initial")
-    #expect(Log.osLoggerCount == 1)
+    #expect(Log.osCount == 1)
 
     let second = Log(
       system: "two", category: "second", style: .os, maxExposureLevel: .trace, options: [.prod])
     second.info("next")
-    #expect(Log.osLoggerCount == 2)
+    #expect(Log.osCount == 2)
 
     let firstDuplicate = Log(
       system: "one", category: "first", style: .os, maxExposureLevel: .trace, options: [.prod])
     firstDuplicate.info("again")
-    #expect(Log.osLoggerCount == 2)
+    #expect(Log.osCount == 2)
 
     Log.globalExposureLevel = .error
     let suppressed = Log(
       system: "three", category: "third", style: .os, maxExposureLevel: .trace, options: [.prod])
     suppressed.debug("ignored")
-    #expect(Log.osLoggerCount == 2)
+    #expect(Log.osCount == 2)
     #expect(!Log.Cache.shared.hasOSLogger(for: suppressed))
   }
 }

--- a/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
+++ b/Tests/WrkstrmLogTests/WrkstrmLogTests.swift
@@ -54,12 +54,12 @@ struct WrkstrmLogTests {
     Log.globalExposureLevel = .trace
     let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     log.info("first")
-    #expect(Log.swiftLoggerCount == 1)
+    #expect(Log.swiftCount == 1)
 
     var mutated = log
     mutated.maxFunctionLength = 10
     mutated.info("second")
-    #expect(Log.swiftLoggerCount == 1)
+    #expect(Log.swiftCount == 1)
   }
 
   /// Confirms hashing ignores mutable properties that do not affect identity.
@@ -123,7 +123,7 @@ struct WrkstrmLogTests {
     Log.reset()
     Log.globalExposureLevel = .trace
     Log.disabled.info("silence")
-    #expect(Log.swiftLoggerCount == 0)
+    #expect(Log.swiftCount == 0)
   }
 
   /// Ensures path information is cached and reused across log calls.
@@ -166,10 +166,10 @@ struct WrkstrmLogTests {
     Log.globalExposureLevel = .warning
     let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     log.info("suppressed")
-    #expect(Log.swiftLoggerCount == 0)
+    #expect(Log.swiftCount == 0)
     Log.globalExposureLevel = .trace
     log.info("logged")
-    #expect(Log.swiftLoggerCount == 1)
+    #expect(Log.swiftCount == 1)
   }
 
   /// Verifies a logger's max exposure level is respected even when global limits differ.
@@ -180,9 +180,9 @@ struct WrkstrmLogTests {
     let log = Log(style: .swift, maxExposureLevel: .error, options: [.prod])
     #expect(log.maxExposureLevel == .error)
     log.info("suppressed")
-    #expect(Log.swiftLoggerCount == 0)
+    #expect(Log.swiftCount == 0)
     log.error("logged")
-    #expect(Log.swiftLoggerCount == 1)
+    #expect(Log.swiftCount == 1)
   }
 
   /// Validates the debug helper respects exposure limits.
@@ -192,10 +192,10 @@ struct WrkstrmLogTests {
     Log.globalExposureLevel = .info
     let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     log.debug("suppressed")
-    #expect(Log.swiftLoggerCount == 0)
+    #expect(Log.swiftCount == 0)
     Log.globalExposureLevel = .debug
     log.debug("logged")
-    #expect(Log.swiftLoggerCount == 1)
+    #expect(Log.swiftCount == 1)
   }
 
   /// Confirms verbose logs are emitted at the debug level.
@@ -244,10 +244,10 @@ struct WrkstrmLogTests {
     Log.globalExposureLevel = .warning
     let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     log.notice("suppressed")
-    #expect(Log.swiftLoggerCount == 0)
+    #expect(Log.swiftCount == 0)
     Log.globalExposureLevel = .notice
     log.notice("logged")
-    #expect(Log.swiftLoggerCount == 1)
+    #expect(Log.swiftCount == 1)
   }
 
   /// Validates the warning helper respects exposure limits.
@@ -257,10 +257,10 @@ struct WrkstrmLogTests {
     Log.globalExposureLevel = .error
     let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     log.warning("suppressed")
-    #expect(Log.swiftLoggerCount == 0)
+    #expect(Log.swiftCount == 0)
     Log.globalExposureLevel = .warning
     log.warning("logged")
-    #expect(Log.swiftLoggerCount == 1)
+    #expect(Log.swiftCount == 1)
   }
 
   /// Verifies `effectiveLevel(for:)` filters based on exposure settings.
@@ -322,11 +322,11 @@ struct WrkstrmLogTests {
     Log.reset()
     let log = Log(style: .swift, options: [.prod])
     log.error("suppressed")
-    #expect(Log.swiftLoggerCount == 0)
+    #expect(Log.swiftCount == 0)
     Log.globalExposureLevel = .trace
     #expect(log.maxExposureLevel == .critical)
     log.error("still suppressed")
-    #expect(Log.swiftLoggerCount == 0)
+    #expect(Log.swiftCount == 0)
   }
 
   /// Asserts `guard` logs a critical message before terminating execution.
@@ -366,10 +366,10 @@ struct WrkstrmLogTests {
     Log.globalExposureLevel = .trace
     let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     log.info("suppressed")
-    #expect(Log.swiftLoggerCount == 1)
+    #expect(Log.swiftCount == 1)
     Log.overrideLevel(for: log, to: .debug)
     log.info("logged")
-    #expect(Log.swiftLoggerCount == 1)
+    #expect(Log.swiftCount == 1)
   }
   #endif
 
@@ -405,7 +405,7 @@ struct WrkstrmLogTests {
     let log = Log()
     log.info("silence")
     #expect(log.style == .disabled)
-    #expect(Log.swiftLoggerCount == 0)
+    #expect(Log.swiftCount == 0)
   }
 
   /// Ensures a logger with the `.prod` option remains enabled in release builds.
@@ -416,7 +416,7 @@ struct WrkstrmLogTests {
     let log = Log(style: .swift, maxExposureLevel: .trace, options: [.prod])
     log.info("hello")
     #expect(log.style == .swift)
-    #expect(Log.swiftLoggerCount == 1)
+    #expect(Log.swiftCount == 1)
   }
   #endif
 }


### PR DESCRIPTION
This pull request updates the log level mapping for verbose messages in the `Log` struct. The change ensures that verbose messages are now mapped to the `.trace` log level instead of `.debug`, allowing for more granular filtering of log output.

Logging improvements:

* Changed verbose message log level mapping from `.debug` to `.trace` in the `Log` struct in `Sources/WrkstrmLog/Log.swift`.