### PR TITLE
Fix logging cache isolation for concurrent tests

### DIFF
--- a/Sources/WrkstrmLog/Log+Decorator.swift
+++ b/Sources/WrkstrmLog/Log+Decorator.swift
@@ -102,7 +102,7 @@ extension Log {
         var tid: UInt64 = 0
         if pthread_threadid_np(nil, &tid) == 0 { threadId = tid }
         #elseif canImport(Glibc)
-        let tid = syscall(SYS_gettid)
+        let tid = pthread_self()
         if tid > 0 { threadId = UInt64(tid) }
         #endif
 


### PR DESCRIPTION
## Summary
- replace the Linux thread identifier lookup with pthread_self() so JSON logs compile on Glibc targets
- rework Log.Cache to track per-context logger, exposure, and path caches so concurrent tests no longer clear each other
- store a cache context identifier on Log instances and scope logging execution to that context when emitting entries

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68c87faf3a488333aa5eecaacdb572b5